### PR TITLE
Replace group's butterflies with logarithmic interconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Compile verilator and the verilated model with Clang, for a faster compilation time
 - Update BibTeX reference to the MemPool DATE paper
 - Rewrite the `traffic_generator` with DPI calls
+- Replace group's butterflies with logarithmic interconnects
 
 ## 0.4.0 - 2021-07-01
 

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -357,10 +357,10 @@ module mempool_group
     .BeWidth            (DataWidth/8                                  ),
     .ByteOffWidth       (0                                            ),
     .AddrMemWidth       (TCDMAddrMemWidth + idx_width(NumBanksPerTile)),
-    .Topology           (tcdm_interconnect_pkg::BFLY4                 ),
+    .Topology           (tcdm_interconnect_pkg::LIC                   ),
     .AxiVldRdy          (1'b1                                         ),
-    .SpillRegisterReq   (64'b10                                       ),
-    .SpillRegisterResp  (64'b10                                       ),
+    .SpillRegisterReq   (64'b1                                        ),
+    .SpillRegisterResp  (64'b1                                        ),
     .FallThroughRegister(1'b1                                         )
   ) i_east_interco (
     .clk_i          (clk_i                   ),
@@ -443,10 +443,10 @@ module mempool_group
     .BeWidth            (DataWidth/8                                  ),
     .ByteOffWidth       (0                                            ),
     .AddrMemWidth       (TCDMAddrMemWidth + idx_width(NumBanksPerTile)),
-    .Topology           (tcdm_interconnect_pkg::BFLY4                 ),
+    .Topology           (tcdm_interconnect_pkg::LIC                   ),
     .AxiVldRdy          (1'b1                                         ),
-    .SpillRegisterReq   (64'b10                                       ),
-    .SpillRegisterResp  (64'b10                                       ),
+    .SpillRegisterReq   (64'b1                                        ),
+    .SpillRegisterResp  (64'b1                                        ),
     .FallThroughRegister(1'b1                                         )
   ) i_north_interco (
     .clk_i          (clk_i                    ),
@@ -529,10 +529,10 @@ module mempool_group
     .BeWidth            (DataWidth/8                                  ),
     .ByteOffWidth       (0                                            ),
     .AddrMemWidth       (TCDMAddrMemWidth + idx_width(NumBanksPerTile)),
-    .Topology           (tcdm_interconnect_pkg::BFLY4                 ),
+    .Topology           (tcdm_interconnect_pkg::LIC                   ),
     .AxiVldRdy          (1'b1                                         ),
-    .SpillRegisterReq   (64'b10                                       ),
-    .SpillRegisterResp  (64'b10                                       ),
+    .SpillRegisterReq   (64'b1                                        ),
+    .SpillRegisterResp  (64'b1                                        ),
     .FallThroughRegister(1'b1                                         )
   ) i_northeast_interco (
     .clk_i          (clk_i                        ),


### PR DESCRIPTION
We can replace the group's north, northeast, and east radix-4 butterflies with fully-connected crossbars. There is a 40 kGE impact on the group's area (about 1%), and the critical load of the design goes from 0.37 req/core/cycle to 0.40 req/core/cycle.

## Changelog

### Changed

- Replace group's butterflies with logarithmic interconnects

![latency](https://user-images.githubusercontent.com/6261373/128677319-8d1d2525-5173-4026-8955-5edc97d61d12.png)
![throughput](https://user-images.githubusercontent.com/6261373/128677327-c88b179e-ce40-423e-bca6-2317f2f22169.png)

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
