### PR TITLE
[ci] Remove hard-coded LLVM path

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   APPS: "tests"
   RUST_LOG: 'memora=debug'
   VERILATOR_ROOT: '$CI_PROJECT_DIR/install/verilator'
-  CLANG_PATH: '/usr/scratch/riseten/matheusd/llvm/'
+  CLANG_PATH: '/usr/pack/llvm-10.0.1-af'
   PATH: '/home/gitlabci/.cargo/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/condor/bin:/usr/sepp/bin:$VERILATOR_ROOT/bin'
   OBJCACHE: ''
   RISCV_WARNINGS: '-Werror'


### PR DESCRIPTION
With LLVM properly installed internally, we can remove the hardcoded path in the internal CI flow.

This is a minor fixup to #6.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
