### PR TITLE
Increase pending queue in icache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix the elaboration of constant signal with an initial value in the `mempool_system` module
 - Specify Halide's library path while installing
 - Fix the waves scripts to match the new hierarchy names
+- Increase pending queue in icache
 
 ### Changed
 - Compile verilator and the verilated model with Clang, for a faster compilation time

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache.sv
@@ -74,13 +74,14 @@ module snitch_icache #(
 
     // Bundle the parameters up into a proper configuration struct that we can
     // pass to submodules.
+    localparam PENDING_COUNT = 8;
     localparam snitch_icache_pkg::config_t CFG = '{
         NR_FETCH_PORTS:    NR_FETCH_PORTS,
         LINE_WIDTH:        LINE_WIDTH,
         LINE_COUNT:        LINE_COUNT,
         L0_LINE_COUNT:     L0_LINE_COUNT,
         SET_COUNT:         SET_COUNT,
-        PENDING_COUNT:     2,
+        PENDING_COUNT:     PENDING_COUNT,
         FETCH_AW:          FETCH_AW,
         FETCH_DW:          FETCH_DW,
         FILL_AW:           FILL_AW,
@@ -98,7 +99,7 @@ module snitch_icache #(
         L0_EARLY_TAG_WIDTH: (L0_EARLY_TAG_WIDTH == -1) ? FETCH_AW - $clog2(LINE_WIDTH/8) : L0_EARLY_TAG_WIDTH,
         ID_WIDTH_REQ: $clog2(NR_FETCH_PORTS) + 1,
         ID_WIDTH_RESP: 2*NR_FETCH_PORTS,
-        PENDING_IW:  $clog2(2)
+        PENDING_IW:  $clog2(PENDING_COUNT)
     };
 
     // pragma translate_off


### PR DESCRIPTION
This is a hotfix of the instruction cache. The lookup interface is not stallable in specific cases which leads to wrong writes or missed responses. This hotfix increases the queue of the handler to eliminate the need for stalling this interface.

## Changelog

### Fixed
- Increase pending queue in icache

This is a hotfix for #18 

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
