### PR TITLE
Remove the reset synchronizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replace group's butterflies with logarithmic interconnects
 - Do not strip the binaries of debug symbols
 - Remove tile's north/east TCDM connection shuffling from the groups
+- Remove the reset synchronizer from the `mempool_cluster`
 
 ## 0.4.0 - 2021-07-01
 

--- a/hardware/src/mempool_cluster.sv
+++ b/hardware/src/mempool_cluster.sv
@@ -28,20 +28,6 @@ module mempool_cluster
   input  axi_tile_resp_t [NumAXIMasters-1:0] axi_mst_resp_i
 );
 
-  /***********
-   *  Reset  *
-   ***********/
-
-  logic rst_n;
-  rstgen_bypass i_rstgen (
-    .clk_i           (clk_i       ),
-    .rst_ni          (rst_ni      ),
-    .rst_test_mode_ni(rst_ni      ),
-    .test_mode_i     (testmode_i  ),
-    .init_no         (/* Unused */),
-    .rst_no          (rst_n       )
-  );
-
   /************
    *  Groups  *
    ************/
@@ -93,7 +79,7 @@ module mempool_cluster
       .BootAddr    (BootAddr    )
     ) i_group (
       .clk_i                             (clk_i                                            ),
-      .rst_ni                            (rst_n                                            ),
+      .rst_ni                            (rst_ni                                           ),
       .testmode_i                        (testmode_i                                       ),
       .scan_enable_i                     (scan_enable_i                                    ),
       .scan_data_i                       (/* Unconnected */                                ),


### PR DESCRIPTION
We do not need the reset synchronizer, and if we need it, this is dependant on the specific implementation of MemPool (e.g., Pinwheel does not need it). I propose we remove it from the `mempool_cluster`, and let the specific implementations add it at their top-level if they so require. 

## Changelog

### Changed

- Remove the reset synchronizer from the `mempool_cluster`

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
