### PR TITLE
Fix synthesis of `snitch_lsu`

### DIFF
--- a/hardware/deps/snitch/src/snitch_lsu.sv
+++ b/hardware/deps/snitch/src/snitch_lsu.sv
@@ -203,9 +203,8 @@ module snitch_lsu
   // ASSERTIONS
   // ----------------
   // Check for unsupported parameters
-  if (NumOutstandingLoads == 0) begin
-    $error($sformatf("NumOutstandingLoads cannot be 0."));
-  end
+  if (NumOutstandingLoads == 0)
+    $error(1, "[snitch_lsu] NumOutstandingLoads cannot be 0.");
 
   // pragma translate_off
   `ifndef VERILATOR


### PR DESCRIPTION
This PR fixes a construct of `snitch_lsu` added with #13, removing the `$sformatf()` call, which cannot be synthesized. 

## Checklist

- [x] Automated tests pass
- [ ] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
