### PR TITLE
Fix icache lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Specify Halide's library path while installing
 - Fix the waves scripts to match the new hierarchy names
 - Increase pending queue in icache
+- Make serial lookup in icache stallable
 
 ### Changed
 - Compile verilator and the verilated model with Clang, for a faster compilation time

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
@@ -46,13 +46,11 @@ module snitch_icache_lookup #(
     initial assert(CFG != '0);
     `endif
 
-    localparam int unsigned DataAddrWdith = CFG.SET_ALIGN + CFG.COUNT_ALIGN;
+    localparam int unsigned DATA_ADDR_WIDTH = CFG.SET_ALIGN + CFG.COUNT_ALIGN;
 
     typedef struct packed {
         logic [CFG.FETCH_AW-1:0]     addr;
-        logic [CFG.LINE_WIDTH-1:0]   data;
         logic [CFG.ID_WIDTH_REQ-1:0] id;
-        logic                        write;
     } tag_req_t;
 
     typedef struct packed {
@@ -73,13 +71,19 @@ module snitch_icache_lookup #(
 
     // Multiplex read and write access to the RAMs onto one port, prioritizing
     // write accesses.
+    logic [CFG.COUNT_ALIGN:0]   init_count_q;
+    logic                       init_phase;
+
     logic [CFG.COUNT_ALIGN-1:0] tag_addr;
     logic [CFG.SET_COUNT-1:0]   tag_enable;
     logic [CFG.TAG_WIDTH+1:0]   tag_wdata, tag_rdata [CFG.SET_COUNT];
     logic                       tag_write;
-    logic [CFG.COUNT_ALIGN:0]   init_count_q;
-    logic [CFG.COUNT_ALIGN-1:0] data_addr;
-    logic [DataAddrWdith-1:0]   data_bank_addr;
+
+    logic [DATA_ADDR_WIDTH-1:0] data_addr;
+    logic                       data_enable;
+    data_rsp_t                  data_wdata, data_rdata;
+    logic                       data_write;
+
     logic                       req_valid, req_ready;
     tag_req_t                   tag_req_d, tag_req_q;
     tag_rsp_t                   tag_rsp_d, tag_rsp_q;
@@ -95,7 +99,21 @@ module snitch_icache_lookup #(
 
     logic [CFG.SET_ALIGN-1:0] out_set;
 
-    always_comb begin : p_portmux
+    // Initialization and flush FSM
+    always_ff @(posedge clk_i, negedge rst_ni) begin
+        if (!rst_ni)
+            init_count_q <= '0;
+        else if (flush_valid_i)
+            init_count_q <= '0;
+        else if (init_count_q != $unsigned(CFG.LINE_COUNT))
+            init_count_q <= init_count_q + 1;
+    end
+
+    assign init_phase = init_count_q != $unsigned(CFG.LINE_COUNT);
+    assign flush_ready_o = flush_valid_i & (init_count_q == $unsigned(CFG.LINE_COUNT));
+
+    // Tag bank port mux
+    always_comb begin
         write_ready_o = 0;
         in_ready_o = 0;
 
@@ -107,21 +125,16 @@ module snitch_icache_lookup #(
 
         tag_req_d = tag_req_q;
 
-        if (init_count_q != $unsigned(CFG.LINE_COUNT)) begin
+        if (init_phase) begin
             tag_addr   = init_count_q;
             tag_enable = '1;
             tag_write  = 1'b1;
             tag_wdata  = '0;
-        end else  if (write_valid_i) begin
+        end else if (write_valid_i) begin
             tag_addr   = write_addr_i;
             tag_enable = $unsigned(1 << write_set_i);
             tag_write  = 1'b1;
-            write_ready_o = req_ready; // From Fall-through register
-            // Store request to data bank
-            req_valid       = 1'b1;
-            tag_req_d.addr  = {write_set_i, write_addr_i} << CFG.LINE_ALIGN;
-            tag_req_d.data  = write_data_i;
-            tag_req_d.write = 1'b1;
+            write_ready_o = 1'b1;
         end else if (in_valid_i) begin
             // Read the tag banks
             tag_enable = '1;
@@ -130,19 +143,7 @@ module snitch_icache_lookup #(
             req_valid       = 1'b1;
             tag_req_d.addr  = in_addr_i;
             tag_req_d.id    = in_id_i;
-            tag_req_d.write = 1'b0;
         end
-    end
-
-    assign flush_ready_o = flush_valid_i & (init_count_q == $unsigned(CFG.LINE_COUNT));
-
-    always_ff @(posedge clk_i, negedge rst_ni) begin
-        if (!rst_ni)
-            init_count_q <= '0;
-        else if (flush_valid_i)
-            init_count_q <= '0;
-        else if (init_count_q != $unsigned(CFG.LINE_COUNT))
-            init_count_q <= init_count_q + 1;
     end
 
     // Tag stage
@@ -188,7 +189,7 @@ module snitch_icache_lookup #(
         .ready_o    (req_ready),
         .data_i     (tag_req_d),
         .valid_o    (tag_valid),
-        .ready_i    (tag_ready),
+        .ready_i    (tag_ready && !data_write),
         .data_o     (tag_req_q)
     );
 
@@ -203,7 +204,7 @@ module snitch_icache_lookup #(
             line_hit[i] = tag_rdata[i][CFG.TAG_WIDTH+1] && tag_rdata[i][CFG.TAG_WIDTH-1:0] == required_tag;
             errors[i] = tag_rdata[i][CFG.TAG_WIDTH] && line_hit[i];
         end
-        tag_rsp_d.hit = |line_hit & ~tag_req_q.write; // Don't let refills trigger "valid" lookups
+        tag_rsp_d.hit = |line_hit;
         tag_rsp_d.error = |errors;
     end
 
@@ -213,8 +214,8 @@ module snitch_icache_lookup #(
         .empty_o  (               )
     );
 
-    `FF(req_handshake, req_valid && req_ready && !tag_req_d.write, 1'b0, clk_i, rst_ni)
-    `FF(tag_handshake, tag_valid && tag_ready && !tag_req_q.write, 1'b0, clk_i, rst_ni)
+    `FF(req_handshake, req_valid && req_ready, 1'b0, clk_i, rst_ni)
+    `FF(tag_handshake, tag_valid && tag_ready && !data_write, 1'b0, clk_i, rst_ni)
     //`FF(data_handshake, data_valid && data_ready, 1'b0, clk_i, rst_ni)
     assign data_handshake = data_valid && data_ready;
 
@@ -229,23 +230,38 @@ module snitch_icache_lookup #(
         .ready_o      (req_ready_ft),
         .data_i       (tag_rsp_d   ),
         .valid_o      (tag_valid_ft),
-        .ready_i      (tag_handshake),
+        .ready_i      (tag_valid && tag_ready && !data_write),
         .data_o       (tag_rsp_q   )
     );
 
     //`ASSERT(req_ftready, req_ready_ft == req_ready)
     //`ASSERT(tag_ftvalid, tag_valid_ft == tag_valid)
     `ASSERT(reqhandshake, req_handshake |-> req_ready_ft);
-    `ASSERT(taghandshake, tag_handshake |-> tag_valid_ft && tag_ready_ft);
+    `ASSERT(taghandshake, tag_valid && tag_ready && !data_write |->  tag_valid_ft);
+    `ASSERT(tagpophandshake, tag_handshake |->  tag_ready_ft);
     `ASSERT(datahandshake, data_handshake |-> data_valid_ft);
 
     // Data stage
-    // Single data bank for all sets
+    // Data bank port mux
     always_comb begin
-        data_bank_addr = tag_req_q.addr >> CFG.LINE_ALIGN;
-        if (!tag_req_q.write) begin
-            data_bank_addr[CFG.COUNT_ALIGN +: CFG.SET_ALIGN] = tag_rsp_q.set;
+        // Write interface
+        data_addr   = '0;
+        data_enable = 1'b0;
+        data_wdata  = '0;
+        data_write  = '0;
+
+        if (!init_phase && write_valid_i) begin
+            // Write
+            data_addr   = {write_set_i, write_addr_i};
+            data_enable = 1'b1;
+            data_wdata  = write_data_i;
+            data_write  = 1'b1;
+        end else if (tag_valid) begin
+            data_addr   = {tag_rsp_q.set, tag_req_q.addr[CFG.LINE_ALIGN +: CFG.COUNT_ALIGN]};
+            data_enable = 1'b1;
+            data_write  = 1'b0;
         end
+        // TODO: simplify
     end
 
     tc_sram #(
@@ -253,14 +269,14 @@ module snitch_icache_lookup #(
         .NumWords  ( CFG.LINE_COUNT * CFG.SET_COUNT ),
         .NumPorts  ( 1                              )
     ) i_data (
-        .clk_i   ( clk_i           ),
-        .rst_ni  ( rst_ni          ),
-        .req_i   ( tag_valid       ),
-        .we_i    ( tag_req_q.write ),
-        .addr_i  ( data_bank_addr  ),
-        .wdata_i ( tag_req_q.data  ),
-        .be_i    ( '1              ),
-        .rdata_o ( data_rsp_d      )
+        .clk_i   ( clk_i       ),
+        .rst_ni  ( rst_ni      ),
+        .req_i   ( data_enable ),
+        .we_i    ( data_write  ),
+        .addr_i  ( data_addr   ),
+        .wdata_i ( data_wdata  ),
+        .be_i    ( '1          ),
+        .rdata_o ( data_rdata  )
     );
 
     fall_through_register_2 #(
@@ -272,7 +288,7 @@ module snitch_icache_lookup #(
         .testmode_i   (1'b0      ),
         .valid_i      (tag_handshake),
         .ready_o      (tag_ready_ft),
-        .data_i       (data_rsp_d ),
+        .data_i       (data_rdata   ),
         .valid_o      (data_valid_ft),
         .ready_i      (data_handshake),
         .data_o       (data_rsp_q)
@@ -292,7 +308,7 @@ module snitch_icache_lookup #(
     ) i_data_register (
         .clk_i      (clk_i                        ),
         .rst_ni     (rst_ni                       ),
-        .valid_i    (tag_valid && !tag_req_q.write),
+        .valid_i    (tag_valid && !data_write     ),
         .ready_o    (tag_ready                    ),
         .data_i     (data_req_d                   ),
         .valid_o    (data_valid                   ),

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
@@ -5,17 +5,16 @@
 // Samuel Riedel  <sriedel@iis.ee.ethz.ch>
 
 `include "common_cells/registers.svh"
-`include "common_cells/assertions.svh"
 
 /// An actual cache lookup.
 module snitch_icache_lookup #(
     parameter snitch_icache_pkg::config_t CFG = '0
 )(
-    input  logic clk_i,
-    input  logic rst_ni,
+    input  logic                        clk_i,
+    input  logic                        rst_ni,
 
-    input  logic flush_valid_i,
-    output logic flush_ready_o,
+    input  logic                        flush_valid_i,
+    output logic                        flush_ready_o,
 
     input  logic [CFG.FETCH_AW-1:0]     in_addr_i,
     input  logic [CFG.ID_WIDTH_REQ-1:0] in_id_i,
@@ -39,65 +38,13 @@ module snitch_icache_lookup #(
     input  logic                        write_valid_i,
     output logic                        write_ready_o
 );
-    logic valid_and_hit;
-    assign valid_and_hit = out_valid_o & out_hit_o;
 
     `ifndef SYNTHESIS
     initial assert(CFG != '0);
     `endif
 
-    localparam int unsigned DATA_ADDR_WIDTH = CFG.SET_ALIGN + CFG.COUNT_ALIGN;
-
-    typedef struct packed {
-        logic [CFG.FETCH_AW-1:0]     addr;
-        logic [CFG.ID_WIDTH_REQ-1:0] id;
-    } tag_req_t;
-
-    typedef struct packed {
-        logic [CFG.SET_ALIGN-1:0]    set;
-        logic                        hit;
-        logic                        error;
-    } tag_rsp_t;
-
-    typedef struct packed {
-        logic [CFG.FETCH_AW-1:0]     addr;
-        logic [CFG.ID_WIDTH_REQ-1:0] id;
-        logic [CFG.SET_ALIGN-1:0]    set;
-        logic                        hit;
-        logic                        error;
-    } data_req_t;
-
-    typedef logic [CFG.LINE_WIDTH-1:0] data_rsp_t;
-
-    // Multiplex read and write access to the RAMs onto one port, prioritizing
-    // write accesses.
-    logic [CFG.COUNT_ALIGN:0]   init_count_q;
-    logic                       init_phase;
-
-    logic [CFG.COUNT_ALIGN-1:0] tag_addr;
-    logic [CFG.SET_COUNT-1:0]   tag_enable;
-    logic [CFG.TAG_WIDTH+1:0]   tag_wdata, tag_rdata [CFG.SET_COUNT];
-    logic                       tag_write;
-
-    logic [DATA_ADDR_WIDTH-1:0] data_addr;
-    logic                       data_enable;
-    data_rsp_t                  data_wdata, data_rdata;
-    logic                       data_write;
-
-    logic                       req_valid, req_ready;
-    tag_req_t                   tag_req_d, tag_req_q;
-    tag_rsp_t                   tag_rsp_d, tag_rsp_q, tag_rsp;
-    logic                       tag_valid, tag_ready;
-    logic                       req_handshake;
-    logic                       tag_handshake;
-    logic                       data_handshake;
-    logic                       tag_valid_ft, tag_ready_ft;
-    logic                       data_valid, data_ready;
-    logic                       data_valid_ft, data_ready_ft;
-    data_req_t                  data_req_d, data_req_q;
-    data_rsp_t                  data_rsp_d, data_rsp_q;
-
-    logic [CFG.SET_ALIGN-1:0] out_set;
+    logic [CFG.COUNT_ALIGN:0] init_count_q;
+    logic                     init_phase;
 
     // Initialization and flush FSM
     always_ff @(posedge clk_i, negedge rst_ni) begin
@@ -112,55 +59,85 @@ module snitch_icache_lookup #(
     assign init_phase = init_count_q != $unsigned(CFG.LINE_COUNT);
     assign flush_ready_o = flush_valid_i & (init_count_q == $unsigned(CFG.LINE_COUNT));
 
-    // Tag bank port mux
+    // --------------------------------------------------
+    // Tag stage
+    // --------------------------------------------------
+    typedef struct packed {
+        logic [CFG.FETCH_AW-1:0]     addr;
+        logic [CFG.ID_WIDTH_REQ-1:0] id;
+    } tag_req_t;
+
+    typedef struct packed {
+        logic [CFG.SET_ALIGN-1:0] cset;
+        logic                     hit;
+        logic                     error;
+    } tag_rsp_t;
+
+    logic                       req_valid, req_ready;
+    logic                       req_handshake;
+
+    logic [CFG.COUNT_ALIGN-1:0] tag_addr;
+    logic [CFG.SET_COUNT-1:0]   tag_enable;
+    logic [CFG.TAG_WIDTH+1:0]   tag_wdata, tag_rdata [CFG.SET_COUNT];
+    logic                       tag_write;
+
+    tag_req_t                   tag_req_d, tag_req_q;
+    tag_rsp_t                   tag_rsp_d, tag_rsp_q, tag_rsp;
+    logic                       tag_valid, tag_ready;
+    logic                       tag_handshake;
+
+    logic [CFG.TAG_WIDTH-1:0]   required_tag;
+    logic [CFG.SET_COUNT-1:0]   line_hit;
+
+    // Connect input requests to tag stage
+    assign tag_req_d.addr = in_addr_i;
+    assign tag_req_d.id   = in_id_i;
+
+    // Multiplex read and write access to the tag banks onto one port, prioritizing write accesses
     always_comb begin
-        write_ready_o = 0;
-        in_ready_o = 0;
-
         tag_addr   = in_addr_i >> CFG.LINE_ALIGN;
-        tag_wdata  = {1'b1, write_error_i, write_tag_i};
         tag_enable = '0;
+        tag_wdata  = {1'b1, write_error_i, write_tag_i};
         tag_write  = 1'b0;
-        req_valid  = 1'b0;
 
-        tag_req_d = tag_req_q;
+        write_ready_o = 1'b0;
+        in_ready_o    = 1'b0;
+        req_valid     = 1'b0;
 
         if (init_phase) begin
             tag_addr   = init_count_q;
             tag_enable = '1;
-            tag_write  = 1'b1;
             tag_wdata  = '0;
-        end else if (write_valid_i) begin
-            tag_addr   = write_addr_i;
-            tag_enable = $unsigned(1 << write_set_i);
             tag_write  = 1'b1;
+        end else if (write_valid_i) begin
+            // Write a refill request
+            tag_addr      = write_addr_i;
+            tag_enable    = $unsigned(1 << write_set_i);
+            tag_write     = 1'b1;
             write_ready_o = 1'b1;
         end else if (in_valid_i) begin
-            // Read the tag banks
+            // Check cache
             tag_enable = '1;
             in_ready_o = req_ready;
-            // Store request to data bank
-            req_valid       = 1'b1;
-            tag_req_d.addr  = in_addr_i;
-            tag_req_d.id    = in_id_i;
+            // Request to store data in pipeline
+            req_valid  = 1'b1;
         end
     end
 
-    // Tag stage
-    // Instantiate the RAM sets.
+    // Instantiate the tag sets.
     for (genvar i = 0; i < CFG.SET_COUNT; i++) begin : g_sets
         if (CFG.L1_TAG_SCM) begin : gen_scm
             latch_scm #(
                 .ADDR_WIDTH ($clog2(CFG.LINE_COUNT)),
                 .DATA_WIDTH (CFG.TAG_WIDTH+2       )
             ) i_tag (
-                .clk        ( clk_i                       ),
-                .ReadEnable ( tag_enable[i] && !tag_write ),
-                .ReadAddr   ( tag_addr                    ),
-                .ReadData   ( tag_rdata[i]                ),
-                .WriteEnable( tag_enable[i] && tag_write  ),
-                .WriteAddr  ( tag_addr                    ),
-                .WriteData  ( tag_wdata                   )
+                .clk         ( clk_i                       ),
+                .ReadEnable  ( tag_enable[i] && !tag_write ),
+                .ReadAddr    ( tag_addr                    ),
+                .ReadData    ( tag_rdata[i]                ),
+                .WriteEnable ( tag_enable[i] && tag_write  ),
+                .WriteAddr   ( tag_addr                    ),
+                .WriteData   ( tag_wdata                   )
             );
         end else begin : gen_sram
             tc_sram #(
@@ -180,19 +157,7 @@ module snitch_icache_lookup #(
         end
     end
 
-    // Req handshake
-    `FF(req_handshake, req_valid && req_ready, 1'b0, clk_i, rst_ni)
-
-    // Buffer the metadata
-    `FFL(tag_req_q, tag_req_d, req_valid && req_ready, '0, clk_i, rst_ni)
-    `FF(tag_valid, req_valid ? 1'b1 : (tag_ready && !tag_write) ? 1'b0 : tag_valid, '0, clk_i, rst_ni)
-    assign req_ready = (!tag_valid || tag_ready) && !tag_write;
-
-
-    // Determine which RAM line hit, and multiplex that data to the output.
-    logic [CFG.TAG_WIDTH-1:0] required_tag;
-    logic [CFG.SET_COUNT-1:0] line_hit;
-
+    // Determine which set hit
     always_comb begin
         automatic logic [CFG.SET_COUNT-1:0] errors;
         required_tag = tag_req_q.addr >> (CFG.LINE_ALIGN + CFG.COUNT_ALIGN);
@@ -205,40 +170,67 @@ module snitch_icache_lookup #(
     end
 
     lzc #(.WIDTH(CFG.SET_COUNT)) i_lzc (
-        .in_i     ( line_hit      ),
-        .cnt_o    ( tag_rsp_d.set ),
-        .empty_o  (               )
+        .in_i     ( line_hit       ),
+        .cnt_o    ( tag_rsp_d.cset ),
+        .empty_o  (                )
     );
 
-    `FF(tag_handshake, tag_valid && tag_ready && !data_write, 1'b0, clk_i, rst_ni)
-    //`FF(data_handshake, data_valid && data_ready, 1'b0, clk_i, rst_ni)
-    assign data_handshake = data_valid && data_ready;
+    // Buffer the metadata
+    `FFL(tag_req_q, tag_req_d, req_valid && req_ready, '0, clk_i, rst_ni)
+    `FF(tag_valid, req_valid ? 1'b1 : (tag_ready && !tag_write) ? 1'b0 : tag_valid, '0, clk_i, rst_ni)
+    assign req_ready = (!tag_valid || tag_ready) && !tag_write;
+
+    // Register the handshake of the reg stage to buffer the tag output data in the next cycle
+    `FF(req_handshake, req_valid && req_ready, 1'b0, clk_i, rst_ni)
 
     // Fall-through buffer
     `FFL(tag_rsp_q, tag_rsp_d, req_handshake, '0, clk_i, rst_ni) // And not tag_handshake in current cycle
     assign tag_rsp = req_handshake ? tag_rsp_d : tag_rsp_q;
 
+    // --------------------------------------------------
     // Data stage
+    // --------------------------------------------------
+    localparam int unsigned DATA_ADDR_WIDTH = $clog2(CFG.SET_COUNT) + CFG.COUNT_ALIGN;
+
+    typedef struct packed {
+        logic [CFG.FETCH_AW-1:0]     addr;
+        logic [CFG.ID_WIDTH_REQ-1:0] id;
+        logic [CFG.SET_ALIGN-1:0]    cset;
+        logic                        hit;
+        logic                        error;
+    } data_req_t;
+
+    typedef logic [CFG.LINE_WIDTH-1:0] data_rsp_t;
+
+    logic [DATA_ADDR_WIDTH-1:0] data_addr;
+    logic                       data_enable;
+    data_rsp_t                  data_wdata, data_rdata;
+    logic                       data_write;
+
+    data_req_t                  data_req_d, data_req_q;
+    data_rsp_t                  data_rsp_q;
+    logic                       data_valid, data_ready;
+
+    // Connect tag stage response to data stage request
+    assign data_req_d.addr  = tag_req_q.addr;
+    assign data_req_d.id    = tag_req_q.id;
+    assign data_req_d.cset  = tag_rsp.cset;
+    assign data_req_d.hit   = tag_rsp.hit;
+    assign data_req_d.error = tag_rsp.error;
+
     // Data bank port mux
     always_comb begin
-        // Write interface
-        data_addr   = '0;
-        data_enable = 1'b0;
-        data_wdata  = '0;
-        data_write  = '0;
-
+        // Default read request
+        data_addr   = {tag_rsp.cset, tag_req_q.addr[CFG.LINE_ALIGN +: CFG.COUNT_ALIGN]};
+        data_enable = tag_valid && tag_rsp.hit; // Only read data on hit
+        data_wdata  = write_data_i;
+        data_write  = 1'b0;
+        // Write takes priority
         if (!init_phase && write_valid_i) begin
-            // Write
             data_addr   = {write_set_i, write_addr_i};
             data_enable = 1'b1;
-            data_wdata  = write_data_i;
             data_write  = 1'b1;
-        end else if (tag_valid) begin
-            data_addr   = {tag_rsp.set, tag_req_q.addr[CFG.LINE_ALIGN +: CFG.COUNT_ALIGN]};
-            data_enable = 1'b1;
-            data_write  = 1'b0;
         end
-        // TODO: simplify
     end
 
     tc_sram #(
@@ -256,38 +248,23 @@ module snitch_icache_lookup #(
         .rdata_o ( data_rdata  )
     );
 
-    // Fall-through buffer
-    `FFL(data_rsp_q, data_rdata, tag_handshake && !data_handshake, '0, clk_i, rst_ni)
-    assign out_data_o = tag_handshake ? data_rdata : data_rsp_q;
-
-    assign data_req_d.addr  = tag_req_q.addr;
-    assign data_req_d.id    = tag_req_q.id;
-    assign data_req_d.set   = tag_rsp.set;
-    assign data_req_d.hit   = tag_rsp.hit;
-    assign data_req_d.error = tag_rsp.error;
-
     // Buffer the metadata
     `FFL(data_req_q, data_req_d, tag_valid && tag_ready && !data_write, '0, clk_i, rst_ni)
     `FF(data_valid, (tag_valid && !data_write) ? 1'b1 : data_ready ? 1'b0 : data_valid, '0, clk_i, rst_ni)
     assign tag_ready = (!data_valid || data_ready) && !data_write;
 
-    // stream_register_2 #(
-    //     .T (data_req_t)
-    // ) i_data_register (
-    //     .clk_i      (clk_i                        ),
-    //     .rst_ni     (rst_ni                       ),
-    //     .valid_i    (tag_valid && !data_write     ),
-    //     .ready_o    (tag_ready                    ),
-    //     .data_i     (data_req_d                   ),
-    //     .valid_o    (data_valid                   ),
-    //     .ready_i    (data_ready                   ),
-    //     .data_o     (data_req_q                   )
-    // );
+    // Register the handshake of the tag stage to buffer the data output data in the next cycle
+    `FF(tag_handshake, tag_valid && tag_ready && !data_write, 1'b0, clk_i, rst_ni)
+
+    // Fall-through buffer the read data: Store the read data if the SRAM bank accepted a request in
+    // the previous cycle and if we actually have to buffer them because the receiver is not ready
+    `FFL(data_rsp_q, data_rdata, tag_handshake && !data_ready, '0, clk_i, rst_ni)
+    assign out_data_o = tag_handshake ? data_rdata : data_rsp_q;
 
     // Generate the remaining output signals.
     assign out_addr_o  = data_req_q.addr;
     assign out_id_o    = data_req_q.id;
-    assign out_set_o   = data_req_q.set;
+    assign out_set_o   = data_req_q.cset;
     assign out_hit_o   = data_req_q.hit;
     assign out_error_o = data_req_q.error;
     assign out_valid_o = data_valid;

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
@@ -1,11 +1,11 @@
-// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright 2021 ETH Zurich and University of Bologna.
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
-// Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 // Samuel Riedel  <sriedel@iis.ee.ethz.ch>
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 /// An actual cache lookup.
 module snitch_icache_lookup #(
@@ -50,68 +50,87 @@ module snitch_icache_lookup #(
 
     typedef struct packed {
         logic [CFG.FETCH_AW-1:0]     addr;
-        logic [CFG.COUNT_ALIGN-1:0]  cset;
         logic [CFG.LINE_WIDTH-1:0]   data;
         logic [CFG.ID_WIDTH_REQ-1:0] id;
         logic                        write;
-    } req_t;
+    } tag_req_t;
+
+    typedef struct packed {
+        logic [CFG.SET_ALIGN-1:0]    set;
+        logic                        hit;
+        logic                        error;
+    } tag_rsp_t;
+
+    typedef struct packed {
+        logic [CFG.FETCH_AW-1:0]     addr;
+        logic [CFG.ID_WIDTH_REQ-1:0] id;
+        logic [CFG.SET_ALIGN-1:0]    set;
+        logic                        hit;
+        logic                        error;
+    } data_req_t;
+
+    typedef logic [CFG.LINE_WIDTH-1:0] data_rsp_t;
 
     // Multiplex read and write access to the RAMs onto one port, prioritizing
     // write accesses.
-    logic [CFG.COUNT_ALIGN-1:0] ram_addr                             ;
-    logic [CFG.SET_COUNT-1:0]   ram_enable                           ;
-    logic [CFG.LINE_WIDTH-1:0]  ram_wdata, ram_rdata;
-    logic [CFG.TAG_WIDTH+1:0]   ram_wtag,  ram_rtag  [CFG.SET_COUNT] ;
-    logic                       ram_write                            ;
-    logic                       ram_write_q;
+    logic [CFG.COUNT_ALIGN-1:0] tag_addr;
+    logic [CFG.SET_COUNT-1:0]   tag_enable;
+    logic [CFG.TAG_WIDTH+1:0]   tag_wdata, tag_rdata [CFG.SET_COUNT];
+    logic                       tag_write;
     logic [CFG.COUNT_ALIGN:0]   init_count_q;
     logic [CFG.COUNT_ALIGN-1:0] data_addr;
     logic [DataAddrWdith-1:0]   data_bank_addr;
-    req_t                       data_req_d, data_req_q;
     logic                       req_valid, req_ready;
+    tag_req_t                   tag_req_d, tag_req_q;
+    tag_rsp_t                   tag_rsp_d, tag_rsp_q;
+    logic                       tag_valid, tag_ready;
+    logic                       req_handshake, req_ready_ft;
+    logic                       tag_handshake;
+    logic                       data_handshake;
+    logic                       tag_valid_ft, tag_ready_ft;
+    logic                       data_valid, data_ready;
+    logic                       data_valid_ft, data_ready_ft;
+    data_req_t                  data_req_d, data_req_q;
+    data_rsp_t                  data_rsp_d, data_rsp_q;
 
-    logic out_hit, out_error;
     logic [CFG.SET_ALIGN-1:0] out_set;
 
     always_comb begin : p_portmux
         write_ready_o = 0;
         in_ready_o = 0;
 
-        ram_addr   = in_addr_i >> CFG.LINE_ALIGN;
-        ram_wdata  = write_data_i;
-        ram_wtag   = {1'b1, write_error_i, write_tag_i};
-        ram_enable = '0;
-        ram_write  = 1'b0;
+        tag_addr   = in_addr_i >> CFG.LINE_ALIGN;
+        tag_wdata  = {1'b1, write_error_i, write_tag_i};
+        tag_enable = '0;
+        tag_write  = 1'b0;
         req_valid  = 1'b0;
 
-        data_req_d = data_req_q;
+        tag_req_d = tag_req_q;
 
         if (init_count_q != $unsigned(CFG.LINE_COUNT)) begin
-            ram_addr   = init_count_q;
-            ram_enable = '1;
-            ram_write  = 1'b1;
-            ram_wdata  = '0;
-            ram_wtag   = '0;
+            tag_addr   = init_count_q;
+            tag_enable = '1;
+            tag_write  = 1'b1;
+            tag_wdata  = '0;
         end else  if (write_valid_i) begin
-            ram_addr   = write_addr_i;
-            ram_enable = $unsigned(1 << write_set_i);
-            ram_write  = 1'b1;
-            write_ready_o = 1'b1; // From Fall-through register
+            tag_addr   = write_addr_i;
+            tag_enable = $unsigned(1 << write_set_i);
+            tag_write  = 1'b1;
+            write_ready_o = req_ready; // From Fall-through register
             // Store request to data bank
-            req_valid        = 1'b1;
-            data_req_d.addr  = write_addr_i;
-            data_req_d.cset  = write_set_i;
-            data_req_d.data  = write_data_i;
-            data_req_d.write = 1'b1;
+            req_valid       = 1'b1;
+            tag_req_d.addr  = {write_set_i, write_addr_i} << CFG.LINE_ALIGN;
+            tag_req_d.data  = write_data_i;
+            tag_req_d.write = 1'b1;
         end else if (in_valid_i) begin
             // Read the tag banks
-            ram_enable = '1;
-            in_ready_o = out_ready_i;
+            tag_enable = '1;
+            in_ready_o = req_ready;
             // Store request to data bank
-            req_valid        = 1'b1;
-            data_req_d.addr  = in_addr_i;
-            data_req_d.id    = in_id_i;
-            data_req_d.write = 1'b0;
+            req_valid       = 1'b1;
+            tag_req_d.addr  = in_addr_i;
+            tag_req_d.id    = in_id_i;
+            tag_req_d.write = 1'b0;
         end
     end
 
@@ -126,40 +145,7 @@ module snitch_icache_lookup #(
             init_count_q <= init_count_q + 1;
     end
 
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (!rst_ni) begin
-            ram_write_q <= 0;
-        end else begin
-            ram_write_q <= ram_write;
-        end
-    end
-
-    // The address register keeps track of additional metadata alongside the
-    // looked up tag and data.
-    logic valid_q, valid_d;
-    logic [CFG.FETCH_AW-1:0] addr_q;
-    logic [CFG.ID_WIDTH_REQ-1:0] id_q;
-
-    always_ff @(posedge clk_i, negedge rst_ni) begin
-        if (!rst_ni) begin
-            addr_q <= '0;
-            id_q   <= '0;
-        end else if (valid_d && out_ready_i) begin
-            addr_q <= data_req_q.addr;
-            id_q   <= data_req_q.id;
-        end
-    end
-
-    `FFLARN(out_hit_o, out_hit, valid_d & out_ready_i, 1'b0, clk_i, rst_ni)
-    `FFLARN(out_error_o, out_error, valid_d & out_ready_i, 1'b0, clk_i, rst_ni)
-    `FFLARN(out_set_o, out_set, valid_d & out_ready_i, '0, clk_i, rst_ni)
-
-    // Store data while reading the tag
-    `FFLARN(data_req_q, data_req_d, req_valid & out_ready_i, '0, clk_i, rst_ni)
-    `FF(valid_d, req_valid, 1'b0)
-
-    `FF(valid_q, valid_d & ~data_req_q.write, 1'b0)
-
+    // Tag stage
     // Instantiate the RAM sets.
     for (genvar i = 0; i < CFG.SET_COUNT; i++) begin : g_sets
         if (CFG.L1_TAG_SCM) begin : gen_scm
@@ -167,13 +153,13 @@ module snitch_icache_lookup #(
                 .ADDR_WIDTH ($clog2(CFG.LINE_COUNT)),
                 .DATA_WIDTH (CFG.TAG_WIDTH+2       )
             ) i_tag (
-                .clk        (clk_i                      ),
-                .ReadEnable (ram_enable[i] && !ram_write),
-                .ReadAddr   (ram_addr                   ),
-                .ReadData   (ram_rtag[i]                ),
-                .WriteEnable(ram_enable[i] && ram_write ),
-                .WriteAddr  (ram_addr                   ),
-                .WriteData  (ram_wtag                   )
+                .clk        ( clk_i                       ),
+                .ReadEnable ( tag_enable[i] && !tag_write ),
+                .ReadAddr   ( tag_addr                    ),
+                .ReadData   ( tag_rdata[i]                ),
+                .WriteEnable( tag_enable[i] && tag_write  ),
+                .WriteAddr  ( tag_addr                    ),
+                .WriteData  ( tag_wdata                   )
             );
         end else begin : gen_sram
             tc_sram #(
@@ -183,32 +169,29 @@ module snitch_icache_lookup #(
             ) i_tag (
                 .clk_i   ( clk_i         ),
                 .rst_ni  ( rst_ni        ),
-                .req_i   ( ram_enable[i] ),
-                .we_i    ( ram_write     ),
-                .addr_i  ( ram_addr      ),
-                .wdata_i ( ram_wtag      ),
+                .req_i   ( tag_enable[i] ),
+                .we_i    ( tag_write     ),
+                .addr_i  ( tag_addr      ),
+                .wdata_i ( tag_wdata     ),
                 .be_i    ( '1            ),
-                .rdata_o ( ram_rtag[i]   )
+                .rdata_o ( tag_rdata[i]  )
             );
         end
     end
 
-    // Single data bank for all sets
-    assign data_addr = {data_req_q.write ? data_req_q.addr : data_req_q.addr >> CFG.LINE_ALIGN};
-    assign data_bank_addr = {data_req_q.write ? data_req_q.cset : out_set, data_addr};
-    tc_sram #(
-        .DataWidth ( CFG.LINE_WIDTH                 ),
-        .NumWords  ( CFG.LINE_COUNT * CFG.SET_COUNT ),
-        .NumPorts  ( 1                              )
-    ) i_data (
-        .clk_i   ( clk_i            ),
-        .rst_ni  ( rst_ni           ),
-        .req_i   ( valid_d          ),
-        .we_i    ( data_req_q.write ),
-        .addr_i  ( data_bank_addr   ),
-        .wdata_i ( data_req_q.data  ),
-        .be_i    ( '1               ),
-        .rdata_o ( ram_rdata        )
+    stream_register #(
+        .T (tag_req_t)
+    ) i_tag_register (
+        .clk_i      (clk_i    ),
+        .rst_ni     (rst_ni   ),
+        .clr_i      (1'b0     ),
+        .testmode_i (1'b0     ),
+        .valid_i    (req_valid),
+        .ready_o    (req_ready),
+        .data_i     (tag_req_d),
+        .valid_o    (tag_valid),
+        .ready_i    (tag_ready),
+        .data_o     (tag_req_q)
     );
 
     // Determine which RAM line hit, and multiplex that data to the output.
@@ -217,26 +200,118 @@ module snitch_icache_lookup #(
 
     always_comb begin
         automatic logic [CFG.SET_COUNT-1:0] errors;
-        required_tag = data_req_q.addr >> (CFG.LINE_ALIGN + CFG.COUNT_ALIGN);
+        required_tag = tag_req_q.addr >> (CFG.LINE_ALIGN + CFG.COUNT_ALIGN);
         for (int i = 0; i < CFG.SET_COUNT; i++) begin
-            line_hit[i] = ram_rtag[i][CFG.TAG_WIDTH+1] && ram_rtag[i][CFG.TAG_WIDTH-1:0] == required_tag;
-            errors[i] = ram_rtag[i][CFG.TAG_WIDTH] && line_hit[i];
+            line_hit[i] = tag_rdata[i][CFG.TAG_WIDTH+1] && tag_rdata[i][CFG.TAG_WIDTH-1:0] == required_tag;
+            errors[i] = tag_rdata[i][CFG.TAG_WIDTH] && line_hit[i];
         end
-        out_hit = |line_hit & ~ram_write_q; // Don't let refills trigger "valid" lookups
-        out_error = |errors;
+        tag_rsp_d.hit = |line_hit & ~tag_req_q.write; // Don't let refills trigger "valid" lookups
+        tag_rsp_d.error = |errors;
     end
 
-    assign out_data_o = out_hit_o ? ram_rdata : '0;
-
     lzc #(.WIDTH(CFG.SET_COUNT)) i_lzc (
-        .in_i     ( line_hit  ),
-        .cnt_o    ( out_set   ),
-        .empty_o  (           )
+        .in_i     ( line_hit      ),
+        .cnt_o    ( tag_rsp_d.set ),
+        .empty_o  (               )
+    );
+
+    `FF(req_handshake, req_valid && req_ready && !tag_req_d.write, 1'b0, clk_i, rst_ni)
+    `FF(tag_handshake, tag_valid && tag_ready && !tag_req_q.write, 1'b0, clk_i, rst_ni)
+    //`FF(data_handshake, data_valid && data_ready, 1'b0, clk_i, rst_ni)
+    assign data_handshake = data_valid && data_ready;
+
+    fall_through_register #(
+        .T (tag_rsp_t)
+    ) i_tag_ft_register (
+        .clk_i        (clk_i     ),
+        .rst_ni       (rst_ni    ),
+        .clr_i        (1'b0      ),
+        .testmode_i   (1'b0      ),
+        .valid_i      (req_handshake),
+        .ready_o      (req_ready_ft),
+        .data_i       (tag_rsp_d   ),
+        .valid_o      (tag_valid_ft),
+        .ready_i      (tag_handshake),
+        .data_o       (tag_rsp_q   )
+    );
+
+    //`ASSERT(req_ftready, req_ready_ft == req_ready)
+    //`ASSERT(tag_ftvalid, tag_valid_ft == tag_valid)
+    `ASSERT(reqhandshake, req_handshake |-> req_ready_ft);
+    `ASSERT(taghandshake, tag_handshake |-> tag_valid_ft && tag_ready_ft);
+    `ASSERT(datahandshake, data_handshake |-> data_valid_ft);
+
+    // Data stage
+    // Single data bank for all sets
+    always_comb begin
+        data_bank_addr = tag_req_q.addr >> CFG.LINE_ALIGN;
+        if (!tag_req_q.write) begin
+            data_bank_addr[CFG.COUNT_ALIGN +: CFG.SET_ALIGN] = tag_rsp_q.set;
+        end
+    end
+
+    tc_sram #(
+        .DataWidth ( CFG.LINE_WIDTH                 ),
+        .NumWords  ( CFG.LINE_COUNT * CFG.SET_COUNT ),
+        .NumPorts  ( 1                              )
+    ) i_data (
+        .clk_i   ( clk_i           ),
+        .rst_ni  ( rst_ni          ),
+        .req_i   ( tag_valid       ),
+        .we_i    ( tag_req_q.write ),
+        .addr_i  ( data_bank_addr  ),
+        .wdata_i ( tag_req_q.data  ),
+        .be_i    ( '1              ),
+        .rdata_o ( data_rsp_d      )
+    );
+
+    fall_through_register #(
+        .T (data_rsp_t)
+    ) i_data_ft_register (
+        .clk_i        (clk_i     ),
+        .rst_ni       (rst_ni    ),
+        .clr_i        (1'b0      ),
+        .testmode_i   (1'b0      ),
+        .valid_i      (tag_handshake),
+        .ready_o      (tag_ready_ft),
+        .data_i       (data_rsp_d ),
+        .valid_o      (data_valid_ft),
+        .ready_i      (data_handshake),
+        .data_o       (data_rsp_q)
+    );
+
+    //`ASSERT(tag_ftready, tag_ready_ft == tag_ready)
+    //`ASSERT(data_ftvalid, data_valid_ft == data_valid)
+
+    assign data_req_d.addr  = tag_req_q.addr;
+    assign data_req_d.id    = tag_req_q.id;
+    assign data_req_d.set   = tag_rsp_q.set;
+    assign data_req_d.hit   = tag_rsp_q.hit;
+    assign data_req_d.error = tag_rsp_q.error;
+
+    stream_register #(
+        .T (data_req_t)
+    ) i_data_register (
+        .clk_i      (clk_i                        ),
+        .rst_ni     (rst_ni                       ),
+        .clr_i      (1'b0                         ),
+        .testmode_i (1'b0                         ),
+        .valid_i    (tag_valid && !tag_req_q.write),
+        .ready_o    (tag_ready                    ),
+        .data_i     (data_req_d                   ),
+        .valid_o    (data_valid                   ),
+        .ready_i    (data_ready                   ),
+        .data_o     (data_req_q                   )
     );
 
     // Generate the remaining output signals.
-    assign out_addr_o  = addr_q;
-    assign out_id_o    = id_q;
-    assign out_valid_o = valid_q;
+    assign out_addr_o  = data_req_q.addr;
+    assign out_id_o    = data_req_q.id;
+    assign out_set_o   = data_req_q.set;
+    assign out_hit_o   = data_req_q.hit;
+    assign out_data_o  = data_rsp_q;
+    assign out_error_o = data_req_q.error;
+    assign out_valid_o = data_valid;
+    assign data_ready  = out_ready_i;
 
 endmodule

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache_lookup.sv
@@ -46,18 +46,18 @@ module snitch_icache_lookup #(
     logic [CFG.COUNT_ALIGN:0] init_count_q;
     logic                     init_phase;
 
+    // We are always ready to flush
+    assign flush_ready_o = 1'b1;
+    assign init_phase = init_count_q != $unsigned(CFG.LINE_COUNT);
     // Initialization and flush FSM
     always_ff @(posedge clk_i, negedge rst_ni) begin
         if (!rst_ni)
             init_count_q <= '0;
-        else if (flush_valid_i)
-            init_count_q <= '0;
         else if (init_count_q != $unsigned(CFG.LINE_COUNT))
             init_count_q <= init_count_q + 1;
+        else if (flush_valid_i)
+            init_count_q <= '0;
     end
-
-    assign init_phase = init_count_q != $unsigned(CFG.LINE_COUNT);
-    assign flush_ready_o = flush_valid_i & (init_count_q == $unsigned(CFG.LINE_COUNT));
 
     // --------------------------------------------------
     // Tag stage


### PR DESCRIPTION
Fix the serial lookup module by rewriting it to make it properly stallable. Furthermore, ensure that a writeback will never be stalled, except during initialization.

## Changelog

### Fixed
Make serial lookup in icache stallable

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
- [x] Wait for synthesis results