### PR TITLE
Improve benchmarking features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a trace visualization script `tracevis.py`
 - Add `config` flag to set specific MemPool flavor, either `minpool` or `mempool`
 - Add bypass channels through the groups for the northeast intergroup connection
+- Add capability to quickly write a value via a CSR
 
 ### Fixed
 - Avoid the elaboration of SVA assertions on the `reorder_buffer` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Register wake-up signals and use `wfi` for barriers
 - Bump the dependencies to the latest version (`common_cells`, `register_interface`, `axi`, `tech_cells_generic`)
 - Use the latest version of Modelsim by default
+- Consistently print Verilator's simulation time in decimal
 
 ## 0.4.0 - 2021-07-01
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -53,7 +53,6 @@ endif
 
 QUESTASIM_HOME ?= /usr/pack/questa-$(questa_version)/questasim
 
-questa_args += -voptargs=+acc
 ifdef app
 	preload ?= "$(app_path)/$(app)"
 endif
@@ -128,7 +127,7 @@ $(buildpath)/compile.tcl: $(bender) $(config_mk) Makefile $(MEMPOOL_DIR)/Bender.
 .PHONY: sim
 sim: clean-dasm compile
 	cd $(buildpath) && \
-	$(questa_cmd) vsim $(questa_args) $(library).$(top_level) -do ../scripts/run.tcl
+	$(questa_cmd) vsim -voptargs=+acc $(questa_args) $(library).$(top_level) -do ../scripts/run.tcl
 	./scripts/return_status.sh $(buildpath)/transcript
 
 .PHONY: simc

--- a/hardware/scripts/wave.tcl
+++ b/hardware/scripts/wave.tcl
@@ -5,6 +5,17 @@
 onerror {resume}
 quietly WaveActivateNextPane {} 0
 
+# Add a vector of the core's wfi signal to quickly see which cores are active
+set wfi_names ""
+for {set g 0} {$g < [examine -radix dec /mempool_pkg::NumGroups]} {incr g} {
+  for {set t 0} {$t < [examine -radix dec /mempool_pkg::NumTilesPerGroup]} {incr t} {
+    for {set c 0} {$c < [examine -radix dec mempool_pkg::NumCoresPerTile]} {incr c} {
+      set wfi_names "mempool_tb/dut/i_mempool_cluster/gen_groups[$g]/i_group/gen_tiles[$t]/i_tile/i_tile/gen_cores[$c]/gen_mempool_cc/riscv_core/i_snitch/wfi_q $wfi_names"
+    }
+  }
+}
+eval "add wave {wfi {$wfi_names}}"
+
 # Add all cores from group 0 tile 0
 for {set core 0}  {$core < [examine -radix dec mempool_pkg::NumCoresPerTile]} {incr core} {
     do ../scripts/wave_core.tcl 0 0 $core

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -246,7 +246,7 @@ void VerilatorSimCtrl::PrintStatistics() const {
   std::cout << std::endl
             << "Simulation statistics" << std::endl
             << "=====================" << std::endl
-            << "Executed cycles:  " << time_ / 2 << std::endl
+            << "Executed cycles:  " << std::dec << time_ / 2 << std::endl
             << "Wallclock time:   " << GetExecutionTimeMs() / 1000.0 << " s"
             << std::endl
             << "Simulation speed: " << speed_hz << " cycles/s "

--- a/hardware/tb/verilator/verilator.flags
+++ b/hardware/tb/verilator/verilator.flags
@@ -39,3 +39,6 @@
 
 // Build the model hierarchical. For MinPool, a non-hierarchical model might be faster
 --hierarchical
+
+// Flush streams after each $display. The timing impact is usually nonmeasurable
+--autoflush

--- a/software/halide/Makefile
+++ b/software/halide/Makefile
@@ -30,7 +30,6 @@ $(BINARIES):  $(BIN_DIR)/$(APP_PREFIX)%: %/$(PIPELINE) %/main.c.o $(RUNTIME) $(L
 	mkdir -p $(dir $@)
 	$(RISCV_CC) -I$(HALIDE_INCLUDE) $(RISCV_LDFLAGS) -o $@ $(filter-out $(LINKER_SCRIPT),$^) -T$(RUNTIME_DIR)/link.ld
 	$(RISCV_OBJDUMP) $(RISCV_OBJDUMP_FLAGS) -D $@ > $@.dump
-	$(RISCV_STRIP) $@ -S --strip-unneeded
 
 # Build Halide application
 %.bin: %.cpp

--- a/software/runtime/crt0.S
+++ b/software/runtime/crt0.S
@@ -53,8 +53,7 @@ _reset_vector:
     li      x29, 0
     li      x30, 0
     li      x31, 0
-    la      sp, tcdm_start_address_reg // load stack top from peripheral register
-    lw      sp, 0(sp)
+    la      sp, __stack_start          // load stack
     csrr    a0, mhartid                // get hart id
 #ifdef TOP4_STACK
     srli    t0, a0, 4                  // id / 16

--- a/software/runtime/runtime.h
+++ b/software/runtime/runtime.h
@@ -18,10 +18,7 @@ typedef uint32_t mempool_id_t;
 typedef uint32_t mempool_timer_t;
 
 /// Obtain the number of cores in the current cluster.
-static inline mempool_id_t mempool_get_core_count() {
-  extern uint32_t nr_cores_address_reg;
-  return nr_cores_address_reg;
-}
+static inline mempool_id_t mempool_get_core_count() { return NUM_CORES; }
 
 /// Obtain the ID of the current core.
 static inline mempool_id_t mempool_get_core_id() {

--- a/software/runtime/runtime.h
+++ b/software/runtime/runtime.h
@@ -63,3 +63,20 @@ static inline void mempool_wfi() { asm volatile("wfi"); }
 // If core_id equals -1, wake up all cores.
 static inline void wake_up(uint32_t core_id) { wake_up_reg = core_id; }
 static inline void wake_up_all() { wake_up((uint32_t)-1); }
+
+// Dump a value via CSR
+// This is only supported in simulation and an experimental feature. All writes
+// to unimplemented CSR registers will be dumped by Snitch. This can be
+// exploited to quickly print measurement values from all cores simultaneously
+// without the hassle of printf. To specify multiple metrics, different CSRs can
+// be used.
+// The macro will define a function that will then always print via the same
+// CSR. E.g., `dump(errors, 8)` will define a function with the following
+// signature: `dump_errors(uint32_t val)`, which will print the given value via
+// the 8th register.
+// Alternatively, the `write_csr(reg, val)` macro can be used directly.
+#define dump(name, reg)                                                        \
+  static                                                                       \
+      __attribute__((always_inline)) inline void dump_##name(uint32_t val) {   \
+    asm volatile("csrw " #reg ", %0" ::"rK"(val));                             \
+  }

--- a/software/runtime/runtime.mk
+++ b/software/runtime/runtime.mk
@@ -67,7 +67,7 @@ RISCV_LLVM_TARGET  ?= --target=$(RISCV_TARGET) --sysroot=$(GCC_INSTALL_DIR)/$(RI
 
 RISCV_WARNINGS += -Wunused-variable -Wconversion -Wall -Wextra # -Werror
 RISCV_FLAGS_COMMON_TESTS ?= -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -I$(ROOT_DIR) -I$(HALIDE_INCLUDE) -static
-RISCV_FLAGS_COMMON ?= $(RISCV_FLAGS_COMMON_TESTS) -std=gnu99 -O3 -ffast-math -fno-common -fno-builtin-printf $(DEFINES) $(RISCV_WARNINGS)
+RISCV_FLAGS_COMMON ?= $(RISCV_FLAGS_COMMON_TESTS) -g -std=gnu99 -O3 -ffast-math -fno-common -fno-builtin-printf $(DEFINES) $(RISCV_WARNINGS)
 RISCV_FLAGS_GCC    ?= -mcmodel=medany -Wa,-march=$(RISCV_ARCH_AS) -mtune=mempool # -falign-loops=32 -falign-jumps=32
 RISCV_FLAGS_LLVM   ?= -mcmodel=small -mcpu=mempool-rv32 -mllvm -misched-topdown
 


### PR DESCRIPTION
Add various fixes and changes that help with benchmarking MemPool. Most notable:

- CSR dump
- Add autoflush to Verilator (does not impact simulation time with current applications)
- Add a wave to quickly see which cores are active
- Optimize headless Modelsim simulation to improve simulation speed
- Consistently print the simulation time in Verilator in dec. Previously, small numbers were printed in dec and large ones in hex.

## Changelog

### Added
- Add capability to quickly write a value via a CSR

### Changed
- Consistently print Verilator's simulation time in decimal

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed