### PR TITLE
[ci] Add a timeout to CI stages that could run indefinitely on errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
   ####################
   verilator-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: verilator
     strategy:
       matrix:
@@ -354,6 +355,7 @@ jobs:
   ##################
   run-apps-gcc:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [build-apps-gcc, riscv-isa-sim, verilator-model]
     strategy:
       matrix:
@@ -394,6 +396,7 @@ jobs:
 
   run-apps-llvm:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [build-apps-llvm, riscv-isa-sim, verilator-model]
     strategy:
       matrix:
@@ -434,6 +437,7 @@ jobs:
 
   run-apps-halide:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [build-apps-halide, riscv-isa-sim, verilator-model]
     strategy:
       matrix:
@@ -474,6 +478,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [tc-gcc, riscv-isa-sim, verilator-model]
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump the dependencies to the latest version (`common_cells`, `register_interface`, `axi`, `tech_cells_generic`)
 - Use the latest version of Modelsim by default
 - Consistently print Verilator's simulation time in decimal
+- Add a timeout to CI stages that could run indefinitely on errors
 
 ## 0.4.0 - 2021-07-01
 


### PR DESCRIPTION
Add a timeout to the CI stages.

## Changelog

### Changed
- Add a timeout to CI stages that could run indefinitely on errors

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed