### PR TITLE
[ci] Ignore uncommitted changes in Memora

### DIFF
--- a/scripts/memora_retry.sh
+++ b/scripts/memora_retry.sh
@@ -6,7 +6,7 @@
 
 i=1
 max_attempts=10
-while ! memora "$@"; do
+while ! memora --ignore-uncommitted-changes "$@"; do
   echo "Attempt $i/$max_attempts of 'memora $@' failed."
   if test $i -ge $max_attempts; then
     echo "'memora $@' keeps failing; aborting!"


### PR DESCRIPTION
Since Memora was updated to require a clean repository to get or create a cache entry, our patch-based flow broke as we always have a dirty state. Thanks to an additional update to Memora, the dirty state can be ignored, which is safe in MemPool, since Memora also checks the patches. This commit invokes Memora with the command-line flag to ignore uncommitted changes in the CI.

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
