### PR TITLE
Add support for a multi-banked L2 memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate `patch-hw` and replace it with the `update-deps` Makefile target, which updates and patches the dependencies.
 - Bump bender to `v0.23.2`
 - Bump verilator to `v4.218`
+- Make the L2 memory mutli-banked
 
 ## 0.4.0 - 2021-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Load Reserved and Store Conditional from "A" standard extension of RISC-V to the TCDM adapter
 - Add the `terapool` configuration
 - Add read-only caches to the hierarchical AXI interconnect
+- Add a `memcpy` benchmark
 
 ### Fixed
 - Avoid the elaboration of SVA assertions on the `reorder_buffer` module

--- a/config/config.mk
+++ b/config/config.mk
@@ -29,8 +29,9 @@ include $(MEMPOOL_DIR)/config/$(config).mk
 boot_addr ?= A0000000
 
 # L2 memory configuration (in hex)
-l2_base ?= 80000000
-l2_size ?= 10000
+l2_base  ?= 80000000
+l2_size  ?= 10000
+l2_banks ?= 4
 
 ################################
 ##  Optional functionalities  ##

--- a/hardware/.gitignore
+++ b/hardware/.gitignore
@@ -12,5 +12,6 @@ bender
 *build*
 *results*
 results*
+log/
 plots*
 obj_dir

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -88,7 +88,7 @@ vlog_args += -suppress vlog-2583 -suppress vlog-13314 -suppress vlog-13233
 vlog_args += -work $(library)
 # Defines
 vlog_defs += -DNUM_CORES=$(num_cores) -DNUM_CORES_PER_TILE=$(num_cores_per_tile) -DNUM_GROUPS=$(num_groups)
-vlog_defs += -DL2_BASE="32'h$(l2_base)" -DL2_SIZE="32'h$(l2_size)"
+vlog_defs += -DL2_BASE="32'h$(l2_base)" -DL2_SIZE="32'h$(l2_size)" -DL2_BANKS=$(l2_banks)
 vlog_defs += -DBOOT_ADDR="32'h$(boot_addr)" -DXPULPIMG="1'b$(xpulpimg)"
 vlog_defs += -DSNITCH_TRACE=$(snitch_trace)
 vlog_defs += -DAXI_HIER_RADIX=$(axi_hier_radix) -DAXI_MASTERS_PER_GROUP=$(axi_masters_per_group)
@@ -107,7 +107,7 @@ else
 	veril_flags := --meminit=ram,$(preload)
 endif
 
-cpp_defs  += -DL2_BASE=0x$(l2_base) -DL2_SIZE=0x$(l2_size)
+cpp_defs  += -DL2_BASE=0x$(l2_base) -DL2_SIZE=0x$(l2_size) -DL2_BANKS=$(l2_banks)
 
 .DEFAULT_GOAL := compile
 

--- a/hardware/src/mempool_pkg.sv
+++ b/hardware/src/mempool_pkg.sv
@@ -42,9 +42,24 @@ package mempool_pkg;
   localparam integer unsigned NumBanksPerGroup = NumBanks / NumGroups;
   localparam integer unsigned TCDMAddrMemWidth = $clog2(TCDMSizePerBank / mempool_pkg::BeWidth);
   localparam integer unsigned TCDMAddrWidth    = TCDMAddrMemWidth + idx_width(NumBanksPerGroup);
+
+  // L2
   localparam integer unsigned L2Size           = `ifdef L2_SIZE `L2_SIZE `else 0 `endif; // [B]
-  localparam integer unsigned L2BeWidth        = AxiDataWidth/8;
-  localparam integer unsigned L2ByteOffset     = $clog2(L2BeWidth);
+
+  localparam integer unsigned NumL2Banks       = 4;
+  localparam integer unsigned L2BankSize       = L2Size / NumL2Banks;
+  localparam integer unsigned L2BankWidth      = AxiDataWidth;
+  localparam integer unsigned L2BankBeWidth    = L2BankWidth/8;
+  localparam integer unsigned L2BankByteOffset = $clog2(L2BankBeWidth);
+  localparam integer unsigned L2BankNumWords   = L2BankSize / L2BankBeWidth;
+  localparam integer unsigned L2BankAddrWidth  = $clog2(L2BankNumWords);
+
+  localparam integer unsigned L2Width         = L2BankWidth * NumL2Banks;
+  localparam integer unsigned L2BeWidth       = L2Width/8;
+  localparam integer unsigned L2ByteOffset    = $clog2(L2BeWidth);
+  localparam integer unsigned L2NumWords      = L2Size / L2BankBeWidth;
+  localparam integer unsigned L2AddrWidth     = $clog2(L2Size);
+
 
   typedef logic [AxiCoreIdWidth-1:0] axi_core_id_t;
   typedef logic [AxiTileIdWidth-1:0] axi_tile_id_t;

--- a/hardware/src/mempool_pkg.sv
+++ b/hardware/src/mempool_pkg.sv
@@ -46,19 +46,17 @@ package mempool_pkg;
   // L2
   localparam integer unsigned L2Size           = `ifdef L2_SIZE `L2_SIZE `else 0 `endif; // [B]
 
-  localparam integer unsigned NumL2Banks       = 4;
+  localparam integer unsigned NumL2Banks       = `ifdef L2_BANKS `L2_BANKS `else 1 `endif;
   localparam integer unsigned L2BankSize       = L2Size / NumL2Banks;
   localparam integer unsigned L2BankWidth      = AxiDataWidth;
   localparam integer unsigned L2BankBeWidth    = L2BankWidth/8;
-  localparam integer unsigned L2BankByteOffset = $clog2(L2BankBeWidth);
   localparam integer unsigned L2BankNumWords   = L2BankSize / L2BankBeWidth;
   localparam integer unsigned L2BankAddrWidth  = $clog2(L2BankNumWords);
 
-  localparam integer unsigned L2Width         = L2BankWidth * NumL2Banks;
-  localparam integer unsigned L2BeWidth       = L2Width/8;
-  localparam integer unsigned L2ByteOffset    = $clog2(L2BeWidth);
-  localparam integer unsigned L2NumWords      = L2Size / L2BankBeWidth;
-  localparam integer unsigned L2AddrWidth     = $clog2(L2Size);
+  localparam integer unsigned L2Width          = L2BankWidth * NumL2Banks;
+  localparam integer unsigned L2BeWidth        = L2Width/8;
+  localparam integer unsigned L2ByteOffset     = $clog2(L2BeWidth);
+  localparam integer unsigned L2AddrWidth      = $clog2(L2Size);
 
 
   typedef logic [AxiCoreIdWidth-1:0] axi_core_id_t;

--- a/hardware/tb/mempool_tb.sv
+++ b/hardware/tb/mempool_tb.sv
@@ -209,8 +209,8 @@ module mempool_tb;
     to_mempool_req.aw_valid = 1'b1;
     `wait_for(to_mempool_resp.aw_ready)
     to_mempool_req.aw_valid = 1'b0;
-    to_mempool_req.w.data = data << addr[ByteOffset +: (AxiDataWidth/DataWidth)] * DataWidth;
-    to_mempool_req.w.strb = {BeWidth{1'b1}} << addr[ByteOffset +: (AxiDataWidth/DataWidth)] * BeWidth;
+    to_mempool_req.w.data = data << addr[ByteOffset +: $clog2(AxiDataWidth/DataWidth)] * DataWidth;
+    to_mempool_req.w.strb = {BeWidth{1'b1}} << addr[ByteOffset +: $clog2(AxiDataWidth/DataWidth)] * BeWidth;
     to_mempool_req.w.last = 1'b1;
     to_mempool_req.w.user = '0;
     to_mempool_req.w_valid = 1'b1;
@@ -232,7 +232,7 @@ module mempool_tb;
     to_mempool_req.ar_valid = 1'b0;
     to_mempool_req.r_ready = 1'b1;
     `wait_for(to_mempool_resp.r_valid)
-    data = to_mempool_resp.r.data >> addr[ByteOffset +: (AxiDataWidth/DataWidth)] * DataWidth;
+    data = to_mempool_resp.r.data >> addr[ByteOffset +: $clog2(AxiDataWidth/DataWidth)] * DataWidth;
     resp = to_mempool_resp.r.resp;
     to_mempool_req.r_ready = 1'b0;
     $display("[TB] Read %08x from %08x at %t (resp=%d).", data, addr, $time, resp);

--- a/hardware/tb/mempool_tb_verilator.sv
+++ b/hardware/tb/mempool_tb_verilator.sv
@@ -25,8 +25,6 @@ module mempool_tb_verilator (
   localparam TA          = 0.2ns;
   localparam TT          = 0.8ns;
 
-  localparam L2AddrWidth = 18;
-
  /********************************
    *  Clock and Reset Generation  *
    ********************************/

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/dpi_memutil.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/dpi_memutil.cc
@@ -4,36 +4,17 @@
 
 #include "dpi_memutil.h"
 
-#include <fcntl.h>
-#include <libelf.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 #include <cassert>
 #include <cstring>
+#include <fcntl.h>
 #include <iostream>
+#include <libelf.h>
 #include <sstream>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
 
 #include "sv_scoped.h"
-
-// DPI Exports
-extern "C" {
-
-/**
- * Write |file| to a memory
- *
- * @param file path to a SystemVerilog $readmemh()-compatible file (VMEM file)
- */
-extern void simutil_memload(const char *file);
-
-/**
- * Write a 32 bit word |val| to memory at index |index|
- *
- * @return 1 if successful, 0 otherwise
- */
-extern int simutil_set_mem(int index, const svBitVecVal *val);
-}
 
 namespace {
 // Convenience class for runtime errors when loading an ELF file
@@ -165,31 +146,25 @@ static std::vector<uint8_t> FlattenElfFile(const std::string &filepath) {
       continue;
     }
 
-    if (phdr.p_memsz == 0 || phdr.p_filesz == 0) {
-      std::cout << "Program header number " << i << " in `" << filepath
-                << "' has size 0; ignoring." << std::endl;
+    if (phdr.p_filesz == 0) {
       continue;
     }
 
     if (!any || phdr.p_paddr < low) {
       low = phdr.p_paddr;
-      std::cout << "Program header number " << i << " in `" << filepath
-                << "' low is " << std::hex << low << std::endl;
     }
 
-    Elf32_Addr seg_top = phdr.p_paddr + (phdr.p_memsz - 1);
+    Elf32_Addr seg_top = phdr.p_paddr + (phdr.p_filesz - 1);
     if (seg_top < phdr.p_paddr) {
       std::ostringstream oss;
       oss << "phdr for segment " << i << " has start 0x" << std::hex
-          << phdr.p_paddr << " and size 0x" << phdr.p_memsz
+          << phdr.p_paddr << " and size 0x" << phdr.p_filesz
           << ", which overflows the address space.";
       throw ElfError(filepath, oss.str());
     }
 
     if (!any || seg_top > high) {
       high = seg_top;
-      std::cout << "Program header number " << i << " in `" << filepath
-                << "' high is " << std::hex << high << std::endl;
     }
 
     any = true;
@@ -216,9 +191,6 @@ static std::vector<uint8_t> FlattenElfFile(const std::string &filepath) {
     if (phdr.p_type != PT_LOAD) {
       continue;
     }
-    if (phdr.p_memsz == 0 || phdr.p_filesz == 0) {
-      continue;
-    }
 
     // Check the segment actually fits in the file
     if (file_size < phdr.p_offset + phdr.p_filesz) {
@@ -229,93 +201,16 @@ static std::vector<uint8_t> FlattenElfFile(const std::string &filepath) {
       throw ElfError(filepath, oss.str());
     }
 
-    uint32_t off = phdr.p_paddr - low;
-    uint32_t dst_len = phdr.p_memsz;
-    uint32_t src_len = std::min(phdr.p_filesz, dst_len);
-
-    if (!dst_len)
+    if (phdr.p_filesz == 0)
       continue;
 
-    std::vector<uint8_t> seg(dst_len, 0);
-    memcpy(&seg[0], file_data + phdr.p_offset, src_len);
+    uint32_t off = phdr.p_paddr - low;
+    std::vector<uint8_t> seg(phdr.p_filesz, 0);
+    memcpy(&seg[0], file_data + phdr.p_offset, phdr.p_filesz);
     ret.AddSegment(off, std::move(seg));
   }
 
   return ret.GetFlat();
-}
-
-// Write a "segment" of data to the given memory area.
-static void WriteSegment(const MemArea &m, uint32_t offset,
-                         const std::vector<uint8_t> &data) {
-  std::cout << "Set `" << m.name << " " << m.location << " " << m.width_byte
-            << " "
-               "0x"
-            << std::hex << m.addr_loc.base
-            << " "
-               "0x"
-            << std::hex << m.addr_loc.size << " "
-            << "write with offset: 0x" << std::hex << offset << " "
-            << "write with size: 0x" << std::hex << data.size() << "\n";
-  assert(m.width_byte <= 128);
-  assert(m.addr_loc.size == 0 || offset + data.size() <= m.addr_loc.size);
-  assert((offset % m.width_byte) == 0);
-
-  // If this fails to set scope, it will throw an error which should
-  // be caught at this function's callsite.
-  SVScoped scoped(m.location.data());
-
-  // This "mini buffer" is used to transfer each write to SystemVerilog. It's
-  // not massively efficient, but doing so ensures that we pass 1024 bits (128
-  // bytes) of initialised data each time. This is for simutil_set_mem (defined
-  // in prim_util_memload.svh), whose "val" argument has SystemVerilog type bit
-  // [1023:0].
-  uint8_t minibuf[128];
-  memset(minibuf, 0, sizeof minibuf);
-  assert(m.width_byte <= sizeof minibuf);
-
-  uint32_t full_data_words = data.size() / m.width_byte;
-  uint32_t part_data_word_len = data.size() % m.width_byte;
-  bool has_part_data_word = part_data_word_len != 0;
-
-  uint32_t word_offset = offset / m.width_byte;
-
-  // Copy the full data words
-  for (uint32_t i = 0; i < full_data_words; ++i) {
-    uint32_t dst_word = word_offset + i;
-    uint32_t src_byte = i * m.width_byte;
-    memcpy(minibuf, &data[src_byte], m.width_byte);
-    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-          << std::hex << dst_word * m.width_byte << ".";
-      throw std::runtime_error(oss.str());
-    }
-  }
-
-  // Copy any partial data, zeroing minibuf first to ensure that the latter
-  // bytes in the word are zero.
-  if (has_part_data_word) {
-    memset(minibuf, 0, sizeof minibuf);
-    uint32_t dst_word = word_offset + full_data_words;
-    uint32_t src_byte = full_data_words * m.width_byte;
-    memcpy(minibuf, &data[src_byte], part_data_word_len);
-    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-          << std::hex << dst_word * m.width_byte << " (partial data word).";
-      throw std::runtime_error(oss.str());
-    }
-  }
-}
-
-static void WriteElfToMem(const MemArea &m, const std::string &filepath) {
-  WriteSegment(m, 0, FlattenElfFile(filepath));
-}
-
-static void WriteVmemToMem(const MemArea &m, const std::string &filepath) {
-  SVScoped scoped(m.location.data());
-  // TODO: Add error handling.
-  simutil_memload(filepath.data());
 }
 
 // Merge seg0 and seg1, overwriting any overlapping data in seg0 with
@@ -413,66 +308,47 @@ std::vector<uint8_t> StagedMem::GetFlat() const {
   return ret;
 }
 
-bool DpiMemUtil::RegisterMemoryArea(const std::string name,
-                                    const std::string location) {
-  // Default to 32bit width and no address
-  return RegisterMemoryArea(name, location, 32, nullptr);
-}
+void DpiMemUtil::RegisterMemoryArea(const std::string &name, uint32_t base,
+                                    const MemArea *mem_area) {
+  assert(mem_area);
 
-bool DpiMemUtil::RegisterMemoryArea(const std::string name,
-                                    const std::string location,
-                                    size_t width_bit,
-                                    const MemAreaLoc *addr_loc) {
-  assert((width_bit <= 1024) &&
-         "TODO: Memory loading only supported up to 1024 bits.");
-  assert(width_bit % 8 == 0);
-
-  // First, create and register the memory by name
-  MemArea mem = {.name = name,
-                 .location = location,
-                 .width_byte = (uint32_t)width_bit / 8,
-                 .addr_loc = {.base = 0, .size = 0}};
-  auto ret = name_to_mem_.emplace(name, mem);
-  if (ret.second == false) {
-    std::cerr << "ERROR: Can not register \"" << name << "\" at: \"" << location
-              << "\" (Previously defined at: \"" << ret.first->second.location
-              << "\")" << std::endl;
-    return false;
+  // Check that we don't overflow the address space.
+  uint32_t size = mem_area->GetSizeBytes();
+  uint32_t addr_top = base + (size - 1);
+  if (addr_top < base) {
+    std::ostringstream oss;
+    oss << "Cannot register '" << name << "' at at 0x" << std::hex << base
+        << " because it has size 0x" << size
+        << " and the top would overflow the top of the address space.";
+    throw std::runtime_error(oss.str());
   }
 
-  MemArea *stored_mem_area = &ret.first->second;
-
-  // If we have no address information, there's nothing more to do. However, if
-  // we do have address information, we should add an entry to addr_to_mem_.
-  if (!addr_loc) {
-    return true;
+  size_t new_idx = mem_areas_.size();
+  auto pr = name_to_mem_.emplace(name, new_idx);
+  if (!pr.second) {
+    const MemArea &stored = *mem_areas_[pr.first->second];
+    std::ostringstream oss;
+    oss << "Cannot register '" << name << "' at: '" << mem_area->GetScope()
+        << "' (Previously defined at: '" << stored.GetScope() << "')"
+        << std::endl;
+    throw std::runtime_error(oss.str());
   }
 
-  // Check that the size of the new area is positive, and that we don't overflow
-  // the address space.
-  if (addr_loc->size == 0) {
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because it has zero size.\n";
-    return false;
-  }
-  uint32_t addr_top = addr_loc->base + (addr_loc->size - 1);
-  if (addr_top < addr_loc->base) {
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because it overflows the top of the address space.\n";
-    return false;
-  }
-
-  auto clash = addr_to_mem_.EmplaceDisjoint(addr_loc->base, addr_top,
-                                            std::move(stored_mem_area));
+  auto clash = addr_to_mem_.EmplaceDisjoint(base, addr_top, std::move(new_idx));
   if (clash) {
     assert(*clash);
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because its address range overlaps the existing area `"
-              << (*clash)->name << "'.\n";
-    return false;
+    // Remove the entry we added to name_to_mem_ above
+    name_to_mem_.erase(pr.first);
+
+    std::ostringstream oss;
+    oss << "Cannot register '" << name << "' at 0x" << std::hex << base
+        << " because its address range overlaps an existing area.";
+    throw std::runtime_error(oss.str());
   }
-  stored_mem_area->addr_loc = *addr_loc;
-  return true;
+
+  mem_areas_.push_back(mem_area);
+  base_addrs_.push_back(base);
+  names_.push_back(name);
 }
 
 MemImageType DpiMemUtil::GetMemImageType(const std::string &path,
@@ -483,16 +359,14 @@ MemImageType DpiMemUtil::GetMemImageType(const std::string &path,
 void DpiMemUtil::PrintMemRegions() const {
   std::cout << "Registered memory regions:" << std::endl;
   for (const auto &pr : name_to_mem_) {
-    const MemArea &m = pr.second;
-    std::cout << "\t'" << m.name << "' (" << m.width_byte * 8
-              << "bits) at location: '" << m.location << "'";
-    if (m.addr_loc.size) {
-      uint32_t low = m.addr_loc.base;
-      uint32_t high = m.addr_loc.base + m.addr_loc.size - 1;
-      std::cout << " (LMA range [0x" << std::hex << low << ", 0x" << high
-                << "])" << std::dec;
-    }
-    std::cout << std::endl;
+    const MemArea &mem = *mem_areas_[pr.second];
+    uint32_t base = base_addrs_[pr.second];
+    uint32_t top = base + mem.GetSizeBytes() - 1;
+
+    std::cout << "\t'" << pr.first << "' (" << mem.GetWidth()
+              << "bits) at location: '" << mem.GetScope() << "'"
+              << " (LMA range [0x" << std::hex << base << ", 0x" << top << "])"
+              << std::dec << std::endl;
   }
 }
 
@@ -520,15 +394,15 @@ void DpiMemUtil::LoadFileToNamedMem(bool verbose, const std::string &name,
               << name << "'." << std::endl;
   }
 
-  const MemArea &m = it->second;
+  const MemArea &m = *mem_areas_[it->second];
 
   try {
     switch (type) {
     case kMemImageElf:
-      WriteElfToMem(m, filepath);
+      m.Write(0, FlattenElfFile(filepath));
       break;
     case kMemImageVmem:
-      WriteVmemToMem(m, filepath);
+      m.LoadVmem(filepath);
       break;
     default:
       assert(0);
@@ -536,7 +410,7 @@ void DpiMemUtil::LoadFileToNamedMem(bool verbose, const std::string &name,
   } catch (const SVScoped::Error &err) {
     std::ostringstream oss;
     oss << "No memory found at `" << err.scope_name_
-        << "' (the scope associated with region `" << m.name << "').";
+        << "' (the scope associated with region `" << name << "').";
     throw std::runtime_error(oss.str());
   }
 }
@@ -552,20 +426,24 @@ void DpiMemUtil::LoadElfToMemories(bool verbose, const std::string &filepath) {
     auto mem_area_it = name_to_mem_.find(mem_name);
     assert(mem_area_it != name_to_mem_.end());
 
-    const MemArea &mem_area = mem_area_it->second;
+    const MemArea &mem_area = *mem_areas_[mem_area_it->second];
 
     for (const auto &seg_pr : staged_mem.GetSegs()) {
       const AddrRange<uint32_t> &seg_rng = seg_pr.first;
       const std::vector<uint8_t> &seg_data = seg_pr.second;
+
+      assert(seg_rng.lo % mem_area.GetWidthByte() == 0);
+      uint32_t lo_word = seg_rng.lo / mem_area.GetWidthByte();
+
       try {
-        WriteSegment(mem_area, seg_rng.lo, seg_data);
+        mem_area.Write(lo_word, seg_data);
       } catch (const SVScoped::Error &err) {
         std::ostringstream oss;
-        std::cout << "No memory found at `" << err.scope_name_
-                  << "' (the scope associated with region `" << mem_area.name
-                  << "', used by a segment that starts at LMA 0x" << std::hex
-                  << mem_area.addr_loc.base + seg_rng.lo << ").";
-        // throw std::runtime_warn(oss.str());
+        oss << "No memory found at `" << err.scope_name_
+            << "' (the scope associated with region `" << mem_name
+            << "', used by a segment that starts at LMA 0x" << std::hex
+            << base_addrs_[mem_area_it->second] + seg_rng.lo << ").";
+        throw std::runtime_error(oss.str());
       }
     }
   }
@@ -576,6 +454,9 @@ void DpiMemUtil::StageElf(bool verbose, const std::string &path) {
   staging_area_.clear();
 
   ElfFile elf(path);
+
+  // Allow subclasses to get at the loaded ELF data if they need it
+  OnElfLoaded(elf.ptr_);
 
   size_t file_size;
   const char *file_data = elf_rawfile(elf.ptr_, &file_size);
@@ -589,21 +470,25 @@ void DpiMemUtil::StageElf(bool verbose, const std::string &path) {
     if (phdr.p_type != PT_LOAD)
       continue;
 
-    if (phdr.p_memsz == 0)
+    if (phdr.p_filesz == 0)
       continue;
 
-    const MemArea &mem_area =
-        GetRegionForSegment(path, i, phdr.p_paddr, phdr.p_memsz);
+    size_t mem_area_idx =
+        GetRegionForSegment(path, i, phdr.p_paddr, phdr.p_filesz);
+
+    const MemArea &mem_area = *mem_areas_[mem_area_idx];
+    uint32_t mem_area_base = base_addrs_[mem_area_idx];
+    const std::string &name = names_[mem_area_idx];
 
     // Check that the segment is aligned correctly for the memory
-    uint32_t local_base = phdr.p_paddr - mem_area.addr_loc.base;
-    if (local_base % mem_area.width_byte) {
+    uint32_t local_base = phdr.p_paddr - mem_area_base;
+    if (local_base % mem_area.GetWidthByte()) {
       std::ostringstream oss;
       oss << "Segment " << i << " has LMA 0x" << std::hex << phdr.p_paddr
           << ", which starts at offset 0x" << local_base
-          << " in the memory region `" << mem_area.name
+          << " in the memory region `" << name
           << "'. This offset is not aligned to the region's word width of "
-          << std::dec << 8 * mem_area.width_byte << " bits.";
+          << std::dec << mem_area.GetWidth() << " bits.";
       throw ElfError(path, oss.str());
     }
 
@@ -622,16 +507,16 @@ void DpiMemUtil::StageElf(bool verbose, const std::string &path) {
 
     if (verbose) {
       std::cout << "Loading segment " << i << " from ELF file `" << path
-                << "' into memory `" << mem_area.name << "'." << std::endl;
+                << "' into memory `" << name << "'." << std::endl;
     }
 
     // Get the StagedMem object associated with this memory area. If
     // there isn't one, make a new empty one.
-    StagedMem &staged_mem = staging_area_[mem_area.name];
+    StagedMem &staged_mem = staging_area_[name];
 
     const char *seg_data = file_data + phdr.p_offset;
-    std::vector<uint8_t> vec(phdr.p_memsz, 0);
-    memcpy(&vec[0], seg_data, std::min(phdr.p_filesz, phdr.p_memsz));
+    std::vector<uint8_t> vec(phdr.p_filesz, 0);
+    memcpy(&vec[0], seg_data, phdr.p_filesz);
 
     staged_mem.AddSegment(local_base, std::move(vec));
   }
@@ -642,9 +527,8 @@ const StagedMem &DpiMemUtil::GetMemoryData(const std::string &mem_name) const {
   return (it == staging_area_.end()) ? empty_ : it->second;
 }
 
-const MemArea &DpiMemUtil::GetRegionForSegment(const std::string &path,
-                                               int seg_idx, uint32_t lma,
-                                               uint32_t mem_sz) const {
+size_t DpiMemUtil::GetRegionForSegment(const std::string &path, int seg_idx,
+                                       uint32_t lma, uint32_t mem_sz) const {
   assert(mem_sz > 0);
 
   auto mem_area_it = addr_to_mem_.find(lma);
@@ -655,9 +539,12 @@ const MemArea &DpiMemUtil::GetRegionForSegment(const std::string &path,
         << ").";
     throw ElfError(path, oss.str());
   }
-  const MemArea *mem_area = mem_area_it->second;
-  assert(mem_area);
-  assert(mem_area->addr_loc.base <= lma);
+  size_t mem_area_idx = mem_area_it->second;
+
+  const MemArea &mem_area = *mem_areas_[mem_area_idx];
+  uint32_t base_addr = base_addrs_[mem_area_idx];
+
+  assert(base_addr <= lma);
 
   uint32_t lma_top = lma + (mem_sz - 1);
   if (lma_top < lma) {
@@ -666,19 +553,19 @@ const MemArea &DpiMemUtil::GetRegionForSegment(const std::string &path,
     throw ElfError(path, oss.str());
   }
 
-  uint32_t local_base = lma - mem_area->addr_loc.base;
-  uint32_t local_top = lma_top - mem_area->addr_loc.base;
+  uint32_t local_base = lma - base_addr;
+  uint32_t local_top = lma_top - base_addr;
 
-  if (mem_area->addr_loc.size <= local_top) {
+  if (mem_area.GetSizeBytes() <= local_top) {
     std::ostringstream oss;
     oss << "Segment " << seg_idx << " has size 0x" << std::hex << mem_sz
         << " bytes. Its LMA of 0x" << lma << " is at offset 0x" << local_base
-        << " in the memory region `" << mem_area->name
+        << " in the memory region `" << names_[mem_area_idx]
         << "', so the segment finishes at offset 0x" << local_top
-        << ", but the memory region is only 0x" << mem_area->addr_loc.size
+        << ", but the memory region is only 0x" << mem_area.GetSizeBytes()
         << " bytes long.";
     throw ElfError(path, oss.str());
   }
 
-  return *mem_area;
+  return mem_area_it->second;
 }

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/dpi_memutil.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/dpi_memutil.h
@@ -1,36 +1,25 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#include <svdpi.h>
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_
 
 #include <map>
+#include <memory>
 #include <string>
+#include <svdpi.h>
 #include <vector>
 
+#include "mem_area.h"
 #include "ranged_map.h"
+
+// Forward declaration for the Elf type from libelf.
+struct Elf;
 
 enum MemImageType {
   kMemImageUnknown = 0,
   kMemImageElf,
   kMemImageVmem,
-};
-
-// The "load" location of a memory area. base is the lowest address in
-// the area, and should correspond to an ELF file's LMA. size is the
-// length of the area in bytes.
-struct MemAreaLoc {
-  uint32_t base;
-  uint32_t size;
-};
-
-struct MemArea {
-  std::string name;     // Unique identifier
-  std::string location; // Design scope location
-  uint32_t width_byte;  // Memory width in bytes
-  MemAreaLoc addr_loc;  // Address location. If !size, location is unknown.
 };
 
 // Staged data for a given memory area.
@@ -73,30 +62,28 @@ private:
  */
 class DpiMemUtil {
 public:
+  virtual ~DpiMemUtil() {}
+
   /**
    * Register a memory as instantiated by generic ram
    *
-   * The |name| must be a unique identifier. The function will return false if
-   * |name| is already used. |location| is the path to the scope of the
-   * instantiated memory, which needs to support the DPI-C interfaces
-   * 'simutil_memload' and 'simutil_set_mem' used for 'vmem' and 'elf' files,
-   * respectively.
+   * The |name| must be a unique identifier. The constructor will
+   * throw a std::runtime_error if |name| is already used.
    *
-   * The |width_bit| argument specifies the with in bits of the target memory
-   * instance (used for packing data). This must be a multiple of 8. If
-   * |addr_loc| is not null, it gives the base and size of the memory for
-   * loading in the address space (corresponding to LMAs in an ELF file).
+   * |base| gives the base address of the memory in a logical address
+   * space that corresponds to LMAs in an ELF file. If this overlaps
+   * with some other registered memory, the constructor throws a
+   * std::runtime_error.
+   *
+   * The |mem_area| argument describes the memory area to be registered and
+   * must not be null. This function does not take ownership of the object,
+   * which must survive at least as long as the DpiMemutil object.
    *
    * Memories must be registered before command arguments are parsed by
    * ParseCommandArgs() in order for them to be known.
    */
-  bool RegisterMemoryArea(const std::string name, const std::string location,
-                          size_t width_bit, const MemAreaLoc *addr_loc);
-
-  /**
-   * Register a memory with default width (32bits)
-   */
-  bool RegisterMemoryArea(const std::string name, const std::string location);
+  void RegisterMemoryArea(const std::string &name, uint32_t base,
+                          const MemArea *mem_area);
 
   /**
    * Guess the type of the file at |path|.
@@ -146,10 +133,24 @@ public:
    */
   const StagedMem &GetMemoryData(const std::string &mem_name) const;
 
+protected:
+  /**
+   * A hook for subclasses to do extra computations with loaded ELF data. This
+   * runs as part of StageElf: after loading the ELF file, but before reading
+   * in the segments.
+   */
+  virtual void OnElfLoaded(Elf *elf_file) {}
+
 private:
-  // Memory area registry
-  std::map<std::string, MemArea> name_to_mem_;
-  RangedMap<uint32_t, MemArea *> addr_to_mem_;
+  // Memory area registry. The maps give indices pointing into the vectors
+  // (which all have the same number of elements). Note that mem_areas_ does
+  // not own the objects that it points to.
+  std::vector<const MemArea *> mem_areas_;
+  std::vector<uint32_t> base_addrs_;
+  std::vector<std::string> names_;
+
+  std::map<std::string, size_t> name_to_mem_;
+  RangedMap<uint32_t, size_t> addr_to_mem_;
 
   // Staging area, loaded by StageElf. The map is keyed by names of memories
   // stored in name_to_mem_. We also ensure that every segment in a StagedMem
@@ -159,9 +160,11 @@ private:
   const StagedMem empty_;
 
   /**
-   * Find a region containing for the given segment's addresses.
+   * Find the index of a memory area containing the given segment's addresses.
    * Raises a std::exception if none is found.
    */
-  const MemArea &GetRegionForSegment(const std::string &path, int seg_idx,
-                                     uint32_t lma, uint32_t mem_sz) const;
+  size_t GetRegionForSegment(const std::string &path, int seg_idx, uint32_t lma,
+                             uint32_t mem_sz) const;
 };
+
+#endif // OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.cc
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mem_area.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <sstream>
+
+#include "sv_scoped.h"
+
+// DPI exports, defined in prim_util_memload.svh
+extern "C" {
+void simutil_memload(const char *file);
+int simutil_set_mem(int index, const svBitVecVal *val);
+int simutil_get_mem(int index, svBitVecVal *val);
+}
+
+MemArea::MemArea(const std::string &scope, uint32_t num_words,
+                 uint32_t width_byte)
+    : scope_(scope), num_words_(num_words), width_byte_(width_byte) {
+  assert(0 < num_words);
+  assert(width_byte <= SV_MEM_WIDTH_BYTES);
+}
+
+void MemArea::Write(uint32_t word_offset,
+                    const std::vector<uint8_t> &data) const {
+  // This "mini buffer" is used to transfer each write to SystemVerilog.
+  // `simutil_set_mem` takes a fixed SV_MEM_WIDTH_BITS-bit vector but it will
+  // only use the bits required for the RAM width. As an example, for a 32-bit
+  // wide RAM only elements 3:0 of `minibuf` will be written to memory. Since
+  // the simulator may still read bits from minibuf it does not use, we must
+  // use a fixed allocation of the full bit vector size to avoid an out of
+  // bounds access.
+  uint8_t minibuf[SV_MEM_WIDTH_BYTES];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(width_byte_ <= sizeof minibuf);
+
+  uint32_t data_words = (data.size() + width_byte_ - 1) / width_byte_;
+  assert(word_offset + data_words <= num_words_);
+
+  for (uint32_t i = 0; i < data_words; ++i) {
+    uint32_t dst_word = word_offset + i;
+    uint32_t phys_addr = ToPhysAddr(dst_word);
+
+    WriteBuffer(minibuf, data, i * width_byte_, dst_word);
+
+    // Both ToPhysAddr and WriteBuffer might set the scope with `SVScoped` so
+    // only construct `SVScoped` once they've both been called so they don't
+    // interact causing incorrect relative path behaviour. If this fails to set
+    // scope, it will throw an error which should be caught at this function's
+    // callsite.
+    SVScoped scoped(scope_);
+    if (!simutil_set_mem(phys_addr, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not set memory at byte offset 0x" << std::hex
+          << dst_word * width_byte_ << ".";
+      throw std::runtime_error(oss.str());
+    }
+  }
+}
+
+std::vector<uint8_t> MemArea::Read(uint32_t word_offset,
+                                   uint32_t num_words) const {
+  assert(word_offset + num_words <= num_words_);
+
+  uint32_t num_bytes = width_byte_ * num_words;
+  assert(num_words <= num_bytes);
+
+  // See Write for an explanation for this buffer.
+  uint8_t minibuf[SV_MEM_WIDTH_BYTES];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(width_byte_ <= sizeof minibuf);
+
+  std::vector<uint8_t> ret;
+  ret.reserve(num_bytes);
+
+  for (uint32_t i = 0; i < num_words; ++i) {
+    uint32_t src_word = word_offset + i;
+    uint32_t phys_addr = ToPhysAddr(src_word);
+
+    ReadToMinibuf(minibuf, phys_addr);
+    ReadBuffer(ret, minibuf, src_word);
+  }
+
+  return ret;
+}
+
+void MemArea::LoadVmem(const std::string &path) const {
+  SVScoped scoped(scope_.c_str());
+  // TODO: Add error handling.
+  simutil_memload(path.c_str());
+}
+
+void MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                          const std::vector<uint8_t> &data, size_t start_idx,
+                          uint32_t dst_word) const {
+  size_t words_left = data.size() - start_idx;
+  size_t to_copy = std::min(words_left, (size_t)width_byte_);
+  if (to_copy < width_byte_) {
+    memset(buf, 0, SV_MEM_WIDTH_BYTES);
+  }
+  memcpy(buf, &data[start_idx], to_copy);
+}
+
+void MemArea::ReadBuffer(std::vector<uint8_t> &data,
+                         const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                         uint32_t src_word) const {
+  // Append the first width_byte_ bytes of buf to data.
+  std::copy_n(reinterpret_cast<const char *>(buf), width_byte_,
+              std::back_inserter(data));
+}
+
+void MemArea::ReadToMinibuf(uint8_t *minibuf, uint32_t phys_addr) const {
+  SVScoped scoped(scope_);
+  if (!simutil_get_mem(phys_addr, (svBitVecVal *)minibuf)) {
+    std::ostringstream oss;
+    oss << "Could not read memory word at physical index 0x" << std::hex
+        << phys_addr << ".";
+    throw std::runtime_error(oss.str());
+  }
+}

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.h
@@ -11,7 +11,7 @@
 
 // This is the maximum width of a memory that's supported by the code in
 // prim_util_memload.svh
-#define SV_MEM_WIDTH_BITS 312
+#define SV_MEM_WIDTH_BITS 1024
 
 // This is the number of bytes to reserve for buffers used to pass data between
 // C++ and SystemVerilog using prim_util_memload.svh. Since this goes over DPI

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.h
@@ -25,17 +25,18 @@ class MemArea {
 public:
   /** Constructor
    *
-   * @param scope  The SystemVerilog scope where the instantiated memory can be
-   *               found. This needs to support the DPI-C interfaces \c
-   *               simutil_memload and \c simutil_set_mem (used for vmem and
-   *               ELF files, respectively).
+   * @param scope     The SystemVerilog scope where the instantiated memory can
+   *                  be found. This needs to support the DPI-C interfaces
+   *                  \c simutil_memload and \c simutil_set_mem (used for vmem
+   *                  and ELF files, respectively).
    *
-   * @param size   The size of the memory in bytes (must be positive and a
-   *               multiple of \p width_byte)
+   * @param num_words The number of words of the memory (must be positive)
    *
-   * @param size   The width of each entry in bytes (must be positive)
+   * @param size      The width of each entry in bytes (must be positive)
    */
-  MemArea(const std::string &scope, uint32_t size, uint32_t width_byte);
+  MemArea(const std::string &scope, uint32_t num_words, uint32_t width_byte);
+  MemArea(const std::vector<std::string> &scopes, uint32_t num_words,
+          uint32_t width_byte);
 
   virtual ~MemArea() {}
 
@@ -74,16 +75,18 @@ public:
   /** Use \c simutil_memload to load a vmem file into the memory */
   virtual void LoadVmem(const std::string &path) const;
 
-  const std::string &GetScope() const { return scope_; }
+  const std::string &GetScope() const { return scopes_[0]; }
   uint32_t GetSizeWords() const { return num_words_; }
   uint32_t GetSizeBytes() const { return num_words_ * width_byte_; }
   uint32_t GetWidthByte() const { return width_byte_; }
   uint32_t GetWidth() const { return 8 * width_byte_; }
 
 protected:
-  std::string scope_;   ///< Design scope (used for accesses over DPI)
+  std::vector<std::string>
+      scopes_;          ///< Design scope (used for accesses over DPI)
   uint32_t num_words_;  ///< Size of the memory area in words
   uint32_t width_byte_; ///< Size of each word in bytes
+  uint32_t num_banks_;  ///< Number of interleaved banks for the memory
 
   /** Write to buf with the data that should be copied to the physical memory
    * for a single memory word.

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/mem_area.h
@@ -1,0 +1,142 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// This is the maximum width of a memory that's supported by the code in
+// prim_util_memload.svh
+#define SV_MEM_WIDTH_BITS 312
+
+// This is the number of bytes to reserve for buffers used to pass data between
+// C++ and SystemVerilog using prim_util_memload.svh. Since this goes over DPI
+// using the svBitVecVal type, we have to round up to the next 32-bit word.
+#define SV_MEM_WIDTH_BYTES (4 * ((SV_MEM_WIDTH_BITS + 31) / 32))
+
+/**
+ * A "memory area", representing a memory in the simulated design.
+ */
+class MemArea {
+public:
+  /** Constructor
+   *
+   * @param scope  The SystemVerilog scope where the instantiated memory can be
+   *               found. This needs to support the DPI-C interfaces \c
+   *               simutil_memload and \c simutil_set_mem (used for vmem and
+   *               ELF files, respectively).
+   *
+   * @param size   The size of the memory in bytes (must be positive and a
+   *               multiple of \p width_byte)
+   *
+   * @param size   The width of each entry in bytes (must be positive)
+   */
+  MemArea(const std::string &scope, uint32_t size, uint32_t width_byte);
+
+  virtual ~MemArea() {}
+
+  /** Write data to this memory area at the given word offset
+   *
+   * This assumes that the result will fit in the memory. If the scope cannot
+   * be set, this throws an SVScoped::Error. If a call to \c simutil_set_mem
+   * fails, this throws a \c std::runtime_error.
+   *
+   * @param word_offset The offset, in words, of the first word that should be
+   *                    written.
+   *
+   * @param data        The data that should be written. If the length is not a
+   *                    multiple of \p word_offset, the last word will be
+   *                    zero-extended.
+   */
+  virtual void Write(uint32_t word_offset,
+                     const std::vector<uint8_t> &data) const;
+
+  /** Read data from this memory area, starting at the given offset.
+   *
+   * This assumes that there are <tt>word_offset + num_words</tt> words in the
+   * memory. Returns a vector with <tt>num_words * width_byte_</tt> elements.
+   *
+   * If the scope cannot be set, this throws an SVScoped::Error. If a call to
+   * simutil_get_mem fails, this throws a std::runtime_error.
+   *
+   * @param word_offset The offset, in words, of the first word that should be
+   *                    written.
+   *
+   * @param num_words   The number of words to read.
+   */
+  virtual std::vector<uint8_t> Read(uint32_t word_offset,
+                                    uint32_t num_words) const;
+
+  /** Use \c simutil_memload to load a vmem file into the memory */
+  virtual void LoadVmem(const std::string &path) const;
+
+  const std::string &GetScope() const { return scope_; }
+  uint32_t GetSizeWords() const { return num_words_; }
+  uint32_t GetSizeBytes() const { return num_words_ * width_byte_; }
+  uint32_t GetWidthByte() const { return width_byte_; }
+  uint32_t GetWidth() const { return 8 * width_byte_; }
+
+protected:
+  std::string scope_;   ///< Design scope (used for accesses over DPI)
+  uint32_t num_words_;  ///< Size of the memory area in words
+  uint32_t width_byte_; ///< Size of each word in bytes
+
+  /** Write to buf with the data that should be copied to the physical memory
+   * for a single memory word.
+   *
+   * The default implementation just uses memcpy to copy the data across. Other
+   * implementations might add scrambling, ECC bits or similar. This must write
+   * every bit of buf that will be used by the memory, but needn't clear bits
+   * further up (this is done outside of the loop).
+   *
+   * @param buf       Destination buffer
+   * @param data      A large buffer that contains the data to be written
+   * @param start_idx An offset into \p data for the start of the memory word
+   * @param dst_word  Logical address of the location being written
+   */
+  virtual void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                           const std::vector<uint8_t> &data, size_t start_idx,
+                           uint32_t dst_word) const;
+
+  /** Extract the logical memory contents corresponding to the physical
+   * memory contents in \p buf and append them to \p data.
+   *
+   * The default implementation just uses \c std::copy_n to copy the data
+   * across. Other implementations might undo scrambling, remove ECC bits or
+   * similar.
+   *
+   * @param data     The target, onto which the extracted memory contents
+   *                 should be appended.
+   *
+   * @param buf      Source buffer (physical memory bits)
+   *
+   * @param src_word Logical address of the location being read
+   */
+  virtual void ReadBuffer(std::vector<uint8_t> &data,
+                          const uint8_t buf[SV_MEM_WIDTH_BYTES],
+                          uint32_t src_word) const;
+
+  /** Convert a logical address to physical address
+   *
+   * Some memories may have a mapping between the address supplied on the
+   * request and the physical address used to access the memory array (for
+   * example scrambled memories). By default logical and physical address are
+   * the same.
+   */
+  virtual uint32_t ToPhysAddr(uint32_t logical_addr) const {
+    return logical_addr;
+  }
+
+  /** Read the memory word at phys_addr into minibuf
+   *
+   * minibuf should be at least SV_MEM_WIDTH_BYTES in size. See the
+   * implementation of MemArea::Write() for the details.
+   */
+  void ReadToMinibuf(uint8_t *minibuf, uint32_t phys_addr) const;
+};
+
+#endif // OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/ranged_map.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/ranged_map.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_
 
 // Utility class representing disjoint segments of memory
 
@@ -175,3 +175,5 @@ public:
 private:
   std::map<rng_t, val_t> map_;
 };
+
+#endif // OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/sv_scoped.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/sv_scoped.cc
@@ -93,3 +93,12 @@ SVScoped::Error::Error(const std::string &scope_name)
   oss << "No such SystemVerilog scope: `" << scope_name << "'.";
   msg_ = oss.str();
 }
+
+std::string SVScoped::join_sv_scopes(const std::string &a,
+                                     const std::string &b) {
+  assert(a.size() && b.size());
+  // If a = ".." and b = "foo.bar", we want "..foo.bar". Otherwise, a
+  // = "..foo" and b = "bar.baz", so we want "..foo.bar.baz"
+  // (inserting a "." between the two)
+  return (a.back() == '.') ? a + b : a + "." + b;
+}

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/sv_scoped.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp/sv_scoped.h
@@ -5,10 +5,10 @@
 #ifndef OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 #define OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 
-#include <svdpi.h>
-
+#include <cassert>
 #include <stdexcept>
 #include <string>
+#include <svdpi.h>
 
 /**
  * Wrapper and guard class for SV Scope
@@ -44,6 +44,9 @@ public:
   private:
     std::string msg_;
   };
+
+  // helper function to join two, possibly relative, scopes correctly.
+  static std::string join_sv_scopes(const std::string &a, const std::string &b);
 
 private:
   svScope prev_scope_;

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_verilator/cpp/verilator_memutil.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_verilator/cpp/verilator_memutil.cc
@@ -4,11 +4,10 @@
 
 #include "verilator_memutil.h"
 
-#include <getopt.h>
-
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <getopt.h>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -99,6 +98,7 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
       {"rominit", required_argument, nullptr, 'r'},
       {"raminit", required_argument, nullptr, 'm'},
       {"flashinit", required_argument, nullptr, 'f'},
+      {"otpinit", required_argument, nullptr, 'o'},
       {"meminit", required_argument, nullptr, 'l'},
       {"verbose-mem-load", no_argument, nullptr, 'V'},
       {"load-elf", required_argument, nullptr, 'E'},
@@ -134,6 +134,10 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
     case 'f':
       load_args.push_back(
           {.name = "flash", .filepath = optarg, .type = kMemImageUnknown});
+      break;
+    case 'o':
+      load_args.push_back(
+          {.name = "otp", .filepath = optarg, .type = kMemImageUnknown});
       break;
     case 'l':
       if (strcasecmp(optarg, "list") == 0) {

--- a/hardware/tb/verilator/lowrisc_dv_verilator_memutil_verilator/cpp/verilator_memutil.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_memutil_verilator/cpp/verilator_memutil.h
@@ -1,11 +1,11 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
 
 //
-// A wrapper class that converts a VerilatorMemutil into a SimCtrlExtension
+// A wrapper class that converts a DpiMemutil into a SimCtrlExtension
 //
 
 #include <memory>
@@ -26,17 +26,15 @@ public:
   // Get underlying DpiMemUtil object
   DpiMemUtil *GetUnderlying() { return mem_util_; }
 
-  // Pass-thru functions to underlying object
-  bool RegisterMemoryArea(const std::string name, const std::string location,
-                          size_t width_bit, const MemAreaLoc *addr_loc) {
-    return mem_util_->RegisterMemoryArea(name, location, width_bit, addr_loc);
-  }
-
-  bool RegisterMemoryArea(const std::string name, const std::string location) {
-    return mem_util_->RegisterMemoryArea(name, location);
+  // Pass-thru function to underlying object
+  void RegisterMemoryArea(const std::string &name, uint32_t base,
+                          const MemArea *mem_area) {
+    return mem_util_->RegisterMemoryArea(name, base, mem_area);
   }
 
 private:
   DpiMemUtil *mem_util_;
   std::unique_ptr<DpiMemUtil> allocation_;
 };
+
+#endif // OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -5,11 +5,10 @@
 #include "verilator_sim_ctrl.h"
 
 #include <getopt.h>
+#include <iostream>
 #include <signal.h>
 #include <sys/stat.h>
 #include <verilated.h>
-
-#include <iostream>
 
 // This is defined by Verilator and passed through the command line
 #ifndef VM_TRACE
@@ -61,6 +60,52 @@ std::pair<int, bool> VerilatorSimCtrl::Exec(int argc, char **argv) {
   return std::make_pair(retcode, true);
 }
 
+static bool read_ul_arg(unsigned long *arg_val, const char *arg_name,
+                        const char *arg_text) {
+  assert(arg_val && arg_name && arg_text);
+
+  bool bad_fmt = false;
+  bool out_of_range = false;
+
+  // We have a stricter input format that strtoul: no leading space and no
+  // leading plus or minus signs (strtoul has magic behaviour if the input
+  // starts with a minus sign, but we don't want that). We're using auto base
+  // detection, but a valid number will always start with 0-9 (since hex
+  // constants start with "0x")
+  if (!(('0' <= arg_text[0]) && (arg_text[0] <= '9'))) {
+    bad_fmt = true;
+  } else {
+    char *txt_end;
+    *arg_val = strtoul(arg_text, &txt_end, 0);
+
+    // If txt_end doesn't point at a \0 then we didn't read the entire
+    // argument.
+    if (*txt_end) {
+      bad_fmt = true;
+    } else {
+      // If the value was too big to fit in an unsigned long, strtoul sets
+      // errno to ERANGE.
+      if (errno != 0) {
+        assert(errno == ERANGE);
+        out_of_range = true;
+      }
+    }
+  }
+
+  if (bad_fmt) {
+    std::cerr << "ERROR: Bad format for " << arg_name << " argument: `"
+              << arg_text << "' is not an unsigned integer.\n";
+    return false;
+  }
+  if (out_of_range) {
+    std::cerr << "ERROR: Bad format for " << arg_name << " argument: `"
+              << arg_text << "' is too big.\n";
+    return false;
+  }
+
+  return true;
+}
+
 bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
   const struct option long_options[] = {
       {"term-after-cycles", required_argument, nullptr, 'c'},
@@ -90,7 +135,10 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
       TraceOn();
       break;
     case 'c':
-      term_after_cycles_ = atoi(optarg);
+      if (!read_ul_arg(&term_after_cycles_, "term-after-cycles", optarg)) {
+        exit_app = true;
+        return false;
+      }
       break;
     case 'h':
       PrintHelp();
@@ -160,6 +208,10 @@ void VerilatorSimCtrl::SetResetDuration(unsigned int cycles) {
   reset_duration_cycles_ = cycles;
 }
 
+void VerilatorSimCtrl::SetTimeout(unsigned int cycles) {
+  term_after_cycles_ = cycles;
+}
+
 void VerilatorSimCtrl::RequestStop(bool simulation_success) {
   request_stop_ = true;
   simulation_success_ &= simulation_success;
@@ -212,7 +264,7 @@ void VerilatorSimCtrl::PrintHelp() const {
                  "  Write a trace file from the start\n\n";
   }
   std::cout << "-c|--term-after-cycles=N\n"
-               "  Terminate simulation after N cycles\n\n"
+               "  Terminate simulation after N cycles. 0 means no timeout.\n\n"
                "-h|--help\n"
                "  Show help\n\n"
                "All arguments are passed to the design and can be used "
@@ -246,7 +298,7 @@ void VerilatorSimCtrl::PrintStatistics() const {
   std::cout << std::endl
             << "Simulation statistics" << std::endl
             << "=====================" << std::endl
-            << "Executed cycles:  " << std::dec << time_ / 2 << std::endl
+            << "Executed cycles:  " << time_ / 2 << std::endl
             << "Wallclock time:   " << GetExecutionTimeMs() / 1000.0 << " s"
             << std::endl
             << "Simulation speed: " << speed_hz << " cycles/s "

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.h
@@ -98,6 +98,15 @@ public:
   void SetResetDuration(unsigned int cycles);
 
   /**
+   * Set a timeout in clock cycles.
+   *
+   * This can be overridden by the user (in either direction) with the
+   * --term-after-cycles command-line argument. Setting to zero means
+   * no timeout, which is the default behaviour.
+   */
+  void SetTimeout(unsigned int cycles);
+
+  /**
    * Request the simulation to stop
    */
   void RequestStop(bool simulation_success);
@@ -129,7 +138,7 @@ private:
   std::chrono::steady_clock::time_point time_begin_;
   std::chrono::steady_clock::time_point time_end_;
   VerilatedTracer tracer_;
-  int term_after_cycles_;
+  unsigned long term_after_cycles_;
   std::vector<SimCtrlExtension *> extension_array_;
 
   /**

--- a/hardware/tb/verilator/mempool_main/mempool_tb_verilator.cc
+++ b/hardware/tb/verilator/mempool_main/mempool_tb_verilator.cc
@@ -27,9 +27,8 @@ int main(int argc, char **argv) {
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
 #ifndef TRAFFIC_GEN
-  MemAreaLoc l2_mem = {.base = L2_BASE, .size = L2_SIZE};
-  memutil.RegisterMemoryArea("ram", "TOP.mempool_tb_verilator.dut.l2_mem", 128,
-                             &l2_mem);
+  MemArea l2_mem("TOP.mempool_tb_verilator.dut.l2_mem", L2_SIZE / 16, 16);
+  memutil.RegisterMemoryArea("ram", L2_BASE, &l2_mem);
   simctrl.RegisterExtension(&memutil);
 #endif
 

--- a/hardware/tb/verilator/mempool_main/mempool_tb_verilator.cc
+++ b/hardware/tb/verilator/mempool_main/mempool_tb_verilator.cc
@@ -15,6 +15,9 @@
 #ifndef L2_SIZE
 #define L2_SIZE 0x00080000
 #endif
+#ifndef L2_BANKS
+#define L2_BANKS 1
+#endif
 
 // Histogram printing function
 extern "C" void print_histogram();
@@ -27,7 +30,12 @@ int main(int argc, char **argv) {
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
 #ifndef TRAFFIC_GEN
-  MemArea l2_mem("TOP.mempool_tb_verilator.dut.l2_mem", L2_SIZE / 16, 16);
+  std::vector<std::string> l2_scope;
+  for (int i = 0; i < L2_BANKS; ++i) {
+    l2_scope.push_back("TOP.mempool_tb_verilator.dut.gen_l2_banks[" +
+                       std::to_string(i) + "].l2_mem");
+  }
+  MemArea l2_mem(l2_scope, L2_SIZE / 16, 16);
   memutil.RegisterMemoryArea("ram", L2_BASE, &l2_mem);
   simctrl.RegisterExtension(&memutil);
 #endif

--- a/software/apps/memcpy/main.c
+++ b/software/apps/memcpy/main.c
@@ -1,0 +1,173 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Author: Samuel Riedel, ETH Zurich
+
+#include <stdint.h>
+#include <string.h>
+
+#include "encoding.h"
+#include "printf.h"
+#include "runtime.h"
+#include "synchronization.h"
+
+#ifndef UNROLL
+#define UNROLL 1
+#endif
+#ifndef GROUP
+#define GROUP 1
+#endif
+
+int8_t ro_data[0xC000] __attribute__((section(".rodata")))
+__attribute__((aligned(0x1000)));
+
+#define SIZE (1024 * 2)
+int32_t volatile dst_a[SIZE] __attribute__((section(".l1")))
+__attribute__((aligned(1024)));
+int32_t volatile dst_b[SIZE] __attribute__((section(".l1")))
+__attribute__((aligned(1024)));
+int32_t volatile dst_c[SIZE] __attribute__((section(".l1")))
+__attribute__((aligned(1024)));
+int32_t volatile dst_d[SIZE] __attribute__((section(".l1")))
+__attribute__((aligned(1024)));
+
+int volatile error __attribute__((section(".l1")));
+
+dump(start, 2);
+dump(end, 3);
+
+void *mempool_memcpy(void *destination, const void *source, size_t num) {
+  if ((((size_t)destination | (size_t)source | num) &
+       (8 * sizeof(uint32_t) - 1)) == 0) {
+    // Aligned to 8 words
+    uint32_t *d = (uint32_t *)destination;
+    const uint32_t *s = (uint32_t *)source;
+    while (d < (uint32_t *)(destination + num)) {
+      uint32_t tmp_0 = *s++;
+      uint32_t tmp_1 = *s++;
+      uint32_t tmp_2 = *s++;
+      uint32_t tmp_3 = *s++;
+      uint32_t tmp_4 = *s++;
+      uint32_t tmp_5 = *s++;
+      uint32_t tmp_6 = *s++;
+      uint32_t tmp_7 = *s++;
+      *d++ = tmp_0;
+      *d++ = tmp_1;
+      *d++ = tmp_2;
+      *d++ = tmp_3;
+      *d++ = tmp_4;
+      *d++ = tmp_5;
+      *d++ = tmp_6;
+      *d++ = tmp_7;
+    }
+  } else {
+    return memcpy(destination, source, num);
+  }
+
+  return destination;
+}
+
+void *parallel_memcpy(void *destination, const void *source, size_t num_bytes,
+                      uint32_t core_id, uint32_t num_cores) {
+  // Assume all cores work together on the memcopy
+  uint32_t group = GROUP;
+  uint32_t chunks = num_bytes / (num_cores / group);
+  uint32_t *d = (uint32_t *)(destination + (core_id / group) * chunks);
+  const uint32_t *s = (uint32_t *)(source + (core_id / group) * chunks);
+  // Offset within the group
+  d += core_id % group;
+  s += core_id % group;
+  // Only run if the data is nicely aligned
+  if ((((size_t)destination | (size_t)source | num_bytes) &
+       (num_cores * sizeof(uint32_t) - 1)) == 0) {
+    while (d < (uint32_t *)(destination + (core_id / group + 1) * chunks)) {
+#if UNROLL == 2
+      uint32_t tmp_0 = *s;
+      s += group;
+      uint32_t tmp_1 = *s;
+      s += group;
+      *d = tmp_0;
+      d += group;
+      *d = tmp_1;
+      d += group;
+#elif UNROLL == 4
+      uint32_t tmp_0 = *s;
+      s += group;
+      uint32_t tmp_1 = *s;
+      s += group;
+      uint32_t tmp_2 = *s;
+      s += group;
+      uint32_t tmp_3 = *s;
+      s += group;
+      *d = tmp_0;
+      d += group;
+      *d = tmp_1;
+      d += group;
+      *d = tmp_2;
+      d += group;
+      *d = tmp_3;
+      d += group;
+#else
+      uint32_t tmp_0 = *s;
+      s += group;
+      *d = tmp_0;
+      d += group;
+#endif
+    }
+  } else {
+    return NULL;
+  }
+  return destination;
+}
+
+int main() {
+  uint32_t num_cores_per_group = NUM_CORES / NUM_GROUPS;
+  uint32_t core_id = mempool_get_core_id();
+  uint32_t group_id = core_id / num_cores_per_group;
+  uint32_t num_cores = mempool_get_core_count();
+  // Initialize barrier and synchronize
+  mempool_barrier_init(core_id);
+
+  if (core_id == 0) {
+    error = 0;
+  }
+
+  int32_t volatile *const src_a = (int32_t *)0x80002000;
+  int32_t volatile *const src_b = (int32_t *)0x80004000;
+  int32_t volatile *const src_c = (int32_t *)0x80008000;
+  int32_t volatile *const src_d = (int32_t *)0x8000C000;
+
+  // Benchmark
+  mempool_start_benchmark();
+  uint32_t time = mempool_get_timer();
+  dump_start(time);
+  switch (group_id) {
+  case 0:
+    parallel_memcpy((void *)dst_a, (const void *)src_a, SIZE * 4,
+                    core_id % num_cores_per_group, num_cores_per_group);
+    break;
+  case 1:
+    parallel_memcpy((void *)dst_b, (const void *)src_b, SIZE * 4,
+                    core_id % num_cores_per_group, num_cores_per_group);
+    break;
+  case 2:
+    parallel_memcpy((void *)dst_c, (const void *)src_c, SIZE * 4,
+                    core_id % num_cores_per_group, num_cores_per_group);
+    break;
+  case 3:
+    parallel_memcpy((void *)dst_d, (const void *)src_d, SIZE * 4,
+                    core_id % num_cores_per_group, num_cores_per_group);
+    break;
+  }
+  time = mempool_get_timer() - time;
+  dump_end(time);
+  mempool_stop_benchmark();
+
+  __atomic_fetch_add(&error, (int)time, __ATOMIC_RELAXED);
+
+  // wait until all cores have finished
+  mempool_barrier(num_cores);
+
+  return error;
+}

--- a/software/runtime/runtime.mk
+++ b/software/runtime/runtime.mk
@@ -60,7 +60,7 @@ RISCV_STRIP   ?= $(RISCV_PREFIX)strip
 
 # Defines
 DEFINES += -DPRINTF_DISABLE_SUPPORT_FLOAT -DPRINTF_DISABLE_SUPPORT_LONG_LONG -DPRINTF_DISABLE_SUPPORT_PTRDIFF_T
-DEFINES += -DNUM_CORES=$(num_cores) -DBOOT_ADDR=0x$(boot_addr) -DL2_BASE=0x$(l2_base) -DL2_SIZE=0x$(l2_size)
+DEFINES += -DNUM_CORES=$(num_cores) -DNUM_GROUPS=$(num_groups) -DBOOT_ADDR=0x$(boot_addr) -DL2_BASE=0x$(l2_base) -DL2_SIZE=0x$(l2_size)
 
 # Specify cross compilation target. This can be omitted if LLVM is built with riscv as default target
 RISCV_LLVM_TARGET  ?= --target=$(RISCV_TARGET) --sysroot=$(GCC_INSTALL_DIR)/$(RISCV_TARGET) --gcc-toolchain=$(GCC_INSTALL_DIR)


### PR DESCRIPTION
Make the L2 memory multi-banked to increase its bandwidth. Also add a `memcpy` benchmark to evaluate performance.

## Changelog

### Added
- Added `memcpy` benchmark

### Changed
- Made L2 memory multi-banked

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed