### PR TITLE
Benchmark improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump bender to `v0.23.2`
 - Bump verilator to `v4.218`
 - Make the L2 memory mutli-banked
+- Improve parsing speed of tracevis by caching the `addr2line` calls
 
 ## 0.4.0 - 2021-07-01
 

--- a/hardware/scripts/gen_trace.py
+++ b/hardware/scripts/gen_trace.py
@@ -728,7 +728,7 @@ def perf_metrics_to_csv(perf_metrics: list, filename: str):
         if write_header:
             dict_writer.writeheader()
         dict_writer.writerows(perf_metrics)
-    print('Wrote performance metrics to %s\n' % filename)
+    print('\nWrote performance metrics to %s\n' % filename)
 
 # -------------------- Main --------------------
 
@@ -834,15 +834,16 @@ def main():
     # Add metadata
     for sec in perf_metrics:
         sec['core'] = core_id
+    # Emit metrics
+    print('\n## Performance metrics')
+    for idx in range(len(perf_metrics)):
+        print('\n' + fmt_perf_metrics(perf_metrics, idx, not args.allkeys))
+        perf_metrics[idx]['section'] = idx
     # Write metrics to CSV
     if csv_file is not None:
         if os.path.split(csv_file)[0] == '':
             csv_file = os.path.join(path, csv_file)
         perf_metrics_to_csv(perf_metrics, csv_file)
-    # Emit metrics
-    print('\n## Performance metrics')
-    for idx in range(len(perf_metrics)):
-        print('\n' + fmt_perf_metrics(perf_metrics, idx, not args.allkeys))
     # Check for any loose ends and warn before exiting
     seq_isns = len(fseq_info['fseq_pcs']) + len(fseq_info['cfg_buf'])
     unseq_left = len(fseq_info['fpss_pcs']) - len(fseq_info['fseq_pcs'])

--- a/hardware/scripts/gen_trace.py
+++ b/hardware/scripts/gen_trace.py
@@ -718,7 +718,25 @@ def perf_metrics_to_csv(perf_metrics: list, filename: str):
         'stall_raw_lsu',
         'stall_raw_acc',
         'stall_lsu',
-        'stall_acc']
+        'stall_acc',
+        'seq_loads_local',
+        'seq_loads_global',
+        'itl_loads_local',
+        'itl_loads_global',
+        'seq_latency_local',
+        'seq_latency_global',
+        'itl_latency_local',
+        'itl_latency_global',
+        'snitch_load_latency',
+        'snitch_load_region',
+        'snitch_load_tile',
+        'snitch_store_region',
+        'snitch_store_region',
+        'snitch_store_tile',
+        'seq_stores_local',
+        'seq_stores_global',
+        'itl_stores_local',
+        'itl_stores_global']
     for key in keys:
         if key not in known_keys:
             known_keys.append(key)

--- a/hardware/scripts/gen_trace.py
+++ b/hardware/scripts/gen_trace.py
@@ -776,9 +776,12 @@ def main():
     if args.csv is not None:
         csv_file = args.csv[0]
     path, filename = os.path.split(args.infile.name)
-    core_id = re.search(r'(\d+)', filename)
-    if core_id:
-        core_id = int(core_id.group(1))
+    core_id_hex = re.search(r'(0x[0-9a-fA-F]+)', filename)
+    core_id_dec = re.search(r'([\d]+)', filename)
+    if core_id_hex:
+        core_id = int(core_id_hex.group(1), 16)
+    elif core_id_dec:
+        core_id = int(core_id_dec.group(1))
     else:
         core_id = -1
     # Prepare stateful data structures

--- a/hardware/src/mempool_cc.sv
+++ b/hardware/src/mempool_cc.sv
@@ -206,7 +206,7 @@ module mempool_cc
 
   always_ff @(posedge rst_i) begin
     if(rst_i) begin
-      $sformat(fn, "trace_hart_%04x.dasm", hart_id_i);
+      $sformat(fn, "trace_hart_0x%04x.dasm", hart_id_i);
       f = $fopen(fn, "w");
       $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
     end

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -298,7 +298,7 @@ void VerilatorSimCtrl::PrintStatistics() const {
   std::cout << std::endl
             << "Simulation statistics" << std::endl
             << "=====================" << std::endl
-            << "Executed cycles:  " << time_ / 2 << std::endl
+            << "Executed cycles:  " << std::dec << time_ / 2 << std::endl
             << "Wallclock time:   " << GetExecutionTimeMs() / 1000.0 << " s"
             << std::endl
             << "Simulation speed: " << speed_hz << " cycles/s "

--- a/scripts/tracevis.py
+++ b/scripts/tracevis.py
@@ -297,10 +297,16 @@ with open(output, 'w') as output_file:
     # JSON header
     output_file.write('{"traceEvents": [\n')
 
+    hartid = 0
     for filename in traces:
-        hartid = 0
-        parsed_nums = re.findall(r'\d+', filename)
-        hartid = int(parsed_nums[-1]) if len(parsed_nums) else hartid+1
+        hartid_hex = re.search(r'(0x[0-9a-fA-F]+)', filename)
+        hartid_dec = re.search(r'([\d]+)', filename)
+        if hartid_hex:
+            hartid = int(hartid_hex.group(1), 16)
+        elif hartid_dec:
+            hartid = int(hartid_dec.group(1))
+        else:
+            hartid = hartid+1
         fails = lines = 0
         last_time = last_cyc = 0
 

--- a/scripts/tracevis.py
+++ b/scripts/tracevis.py
@@ -16,6 +16,7 @@
 import re
 import os
 import sys
+from functools import lru_cache
 import argparse
 
 has_progressbar = True
@@ -28,40 +29,59 @@ except ImportError as e:
 
 
 # line format:
+# Snitch RTL simulation:
 # 101000 82      M         0x00001000 csrr    a0, mhartid     #; comment
 # time   cycle   priv_lvl  pc         insn
+# MemPool RTL simulation:
+# 101000 82      0x00001000 csrr    a0, mhartid     #; comment
+# time   cycle   pc         insn
+# Banshee traces:
+# 00000432 00000206 0005     800101e0  x15:00000064 x15=00000065 # addi ...
+# cycle    instret  hard_id  pc        register                    insn
 
 # regex matches to groups
 # 0 -> time
 # 1 -> cycle
-# 2 -> privilege level
+# 2 -> privilege level (RTL) / hartid (banshee)
 # 3 -> pc (hex with 0x prefix)
 # 4 -> instruction
-# 5 -> args
-LINE_REGEX = r' *(\d+) +(\d+) +([3M1S0U]?) *(0x[0-9a-f]+) ([.\w]+) +(.+)#'
+# 5 -> args (RTL) / empty (banshee)
+# 6 -> comment (RTL) / instruction arguments (banshee)
+RTL_REGEX = r' *(\d+) +(\d+) +([3M1S0U]?) *(0x[0-9a-f]+) ([.\w]+) +(.+)#; (.*)'
+BANSHEE_REGEX = r' *(\d+) (\d+) (\d+) ([0-9a-f]+) *.+ +.+# ([\w\.]*)( +)(.*)'
 
 # regex matches a line of instruction retired by the accelerator
+# 0 -> time
+# 1 -> cycle
 # 2 -> privilege level
-# 3 -> pc (hex with 0x prefix)
-# 4 -> instruction
-# 5 -> args
-ACC_LINE_REGEX = r' +([3M1S0U]?) *(0x[0-9a-f]+) ([.\w]+) +(.+)#'
-
-re_line = re.compile(LINE_REGEX)
-re_acc_line = re.compile(ACC_LINE_REGEX)
+# 3 -> comment
+ACC_LINE_REGEX = r' *(\d+) +(\d+) +([3M1S0U]?) *#; (.*)'
 
 buf = []
 
 
+@lru_cache(maxsize=1024)
+def addr2line_cache(addr):
+    cmd = f'{addr2line} -e {elf} -f -a -i {addr:x}'
+    return os.popen(cmd).read().split('\n')
+
+
 def flush(buf, hartid):
-    global output_file, use_time
+    global output_file
     # get function names
     pcs = [x[3] for x in buf]
-    a2ls = os.popen(
-        f'addr2line -e {elf} -f -a -i {" ".join(pcs)}').read().split('\n')[:-1]
+    a2ls = []
+
+    if cache:
+        for addr in pcs:
+            a2ls += addr2line_cache(int(addr, base=16))[:-1]
+    else:
+        a2ls = os.popen(
+            f'{addr2line} -e {elf} -f -a -i {" ".join(pcs)}'
+        ).read().split('\n')[:-1]
 
     for i in range(len(buf)-1):
-        (time, cyc, priv, pc, instr, args) = buf.pop(0)
+        (time, cyc, priv, pc, instr, args, cmt) = buf.pop(0)
 
         if use_time:
             next_time = int(buf[0][0])
@@ -69,6 +89,9 @@ def flush(buf, hartid):
         else:
             next_time = int(buf[0][1])
             time = int(cyc)
+
+        # Have lookahead time to this instruction?
+        next_time = lah[time] if time in lah else next_time
 
         # print(f'time "{time}", cyc "{cyc}", priv "{priv}", pc "{pc}"'
         #       f', instr "{instr}", args "{args}"', file=sys.stderr)
@@ -82,12 +105,27 @@ def flush(buf, hartid):
         # print(f'pc "{pc}", func "{func}", file "{file}"')
 
         # assemble values for json
-        label = instr
-        cat = instr
-        start_time = time
+        # Doc: https://docs.google.com/document/d/
+        # 1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+        # The name of the event, as displayed in Trace Viewer
+        name = instr
+        # The event categories. This is a comma separated list of categories
+        # for the event. The categories can be used to hide events in the Trace
+        # Viewer UI.
+        cat = 'instr'
+        # The tracing clock timestamp of the event. The timestamps are provided
+        # at microsecond granularity.
+        ts = time
+        # There is an extra parameter dur to specify the tracing clock duration
+        # of complete events in microseconds.
         duration = next_time - time
-        # print(f'"{label}" time {time} next: {next_time}'
-        #       f' duration: {duration}', file=sys.stderr)
+
+        if banshee:
+            # Banshee stores all traces in a single file
+            hartid = priv
+            # In Banshee, each instruction takes one cycle
+            duration = 1
+
         pid = elf+':hartid'+str(hartid)
         funcname = func
 
@@ -100,8 +138,8 @@ def flush(buf, hartid):
         arg_inlined = inlined
 
         output_file.write((
-            f'{{"name": "{label}", "cat": "{cat}", "ph": "X", '
-            f'"ts": {start_time}, "dur": {duration}, "pid": "{pid}", '
+            f'{{"name": "{name}", "cat": "{cat}", "ph": "X", '
+            f'"ts": {ts}, "dur": {duration}, "pid": "{pid}", '
             f'"tid": "{funcname}", "args": {{"pc": "{arg_pc}", '
             f'"instr": "{arg_instr} {arg_args}", "time": "{arg_cycles}", '
             f'"Origin": "{arg_coords}", "inline": "{arg_inlined}"'
@@ -113,35 +151,24 @@ def parse_line(line, hartid):
     # print(line)
     match = re_line.match(line)
     if match:
-        (time, cyc, priv, pc, instr, args) = tuple(
+        (time, cyc, priv, pc, instr, args, cmt) = tuple(
             [match.group(i+1).strip() for i in range(re_line.groups)])
-    # print(match)
-
-    if not match:
-        # match accelerator line with same timestamp as before
-        match = re_acc_line.match(line)
-        if match:
-            (priv, pc, instr, args) = tuple(
-                [match.group(i+1).strip() for i in range(re_acc_line.groups)])
-            # use time,cyc from last line
-            time, cyc = last_time, last_cyc
-        else:
-            return 1
-
-    # print(line)
-    buf.append((time, cyc, priv, pc, instr, args))
-    last_time, last_cyc = time, cyc
+        buf.append((time, cyc, priv, pc, instr, args, cmt))
+        last_time, last_cyc = time, cyc
 
     if len(buf) > 10:
         flush(buf, hartid)
     return 0
 
 
+# Argument parsing
 parser = argparse.ArgumentParser('tracevis', allow_abbrev=True)
 parser.add_argument(
     'elf',
     metavar='<elf>',
     help='The binary executed to generate the traces',
+
+
 )
 parser.add_argument(
     'traces',
@@ -151,19 +178,35 @@ parser.add_argument(
 parser.add_argument(
     '-o',
     '--output',
-    metavar='<trace>',
+    metavar='<json>',
     nargs='?',
     default='chrome.json',
     help='Output JSON file')
+parser.add_argument(
+    '--addr2line',
+    metavar='<path>',
+    nargs='?',
+    default='addr2line',
+    help='`addr2line` binary to use for parsing')
 parser.add_argument(
     '-t',
     '--time',
     action='store_true',
     help='Use the traces time instead of cycles')
 parser.add_argument(
+    '-b',
+    '--banshee',
+    action='store_true',
+    help='Parse Banshee traces')
+parser.add_argument(
+    '--no-cache',
+    action='store_true',
+    help='Disable addr2line caching'
+    ' (slow but might give better traces in some cases)')
+parser.add_argument(
     '-s',
     '--start',
-    metavar='<trace>',
+    metavar='<line>',
     nargs='?',
     type=int,
     default=0,
@@ -171,7 +214,7 @@ parser.add_argument(
 parser.add_argument(
     '-e',
     '--end',
-    metavar='<trace>',
+    metavar='<line>',
     nargs='?',
     type=int,
     default=-1,
@@ -183,10 +226,72 @@ elf = args.elf
 traces = args.traces
 output = args.output
 use_time = args.time
+banshee = args.banshee
+addr2line = args.addr2line
+cache = not args.no_cache
 
-print('elf', elf, file=sys.stderr)
-print('traces', traces, file=sys.stderr)
-print('output', output, file=sys.stderr)
+print('elf:', elf, file=sys.stderr)
+print('traces:', traces, file=sys.stderr)
+print('output:', output, file=sys.stderr)
+print('addr2line:', addr2line, file=sys.stderr)
+print('cache:', cache, file=sys.stderr)
+
+# Compile regex
+if banshee:
+    re_line = re.compile(BANSHEE_REGEX)
+else:
+    re_line = re.compile(RTL_REGEX)
+
+re_acc_line = re.compile(ACC_LINE_REGEX)
+
+
+def offload_lookahead(lines):
+    # dict mapping time stamp of retired instruction to time stamp of
+    # accelerator complete
+    lah = {}
+    searches = []
+    re_load = re.compile(r'([a-z]*[0-9]*|zero) *<~~ Word')
+
+    for line in lines:
+        match = re_line.match(line)
+        if match:
+            (time, cyc, priv, pc, instr, args, cmt) = tuple(
+                [match.group(i+1).strip() for i in range(re_line.groups)])
+            time = int(time) if use_time else int(cyc)
+
+            # register searchers
+            if '<~~ Word' in cmt:
+                if re_load.search(cmt):
+                    dst_reg = re_load.search(cmt).group(1)
+                    pat = f'(lsu) {dst_reg}  <--'
+                    searches.append({'pat': pat, 'start': time})
+                else:
+                    print(f'unsupported load lah: {cmt}')
+
+        # If this line is an acc-only line, get the data
+        if not match:
+            match = re_acc_line.match(line)
+            if match:
+                (time, cyc, priv, cmt) = tuple(
+                    [match.group(i+1).strip()
+                     for i in range(re_acc_line.groups)])
+
+        time = int(time) if use_time else int(cyc)
+
+        # Check for any open searches
+        removes = []
+        for s in searches:
+            if s['pat'] in cmt:
+                lah[s['start']] = time
+                removes.append(s)
+        [searches.remove(r) for r in removes]
+
+    # for l in lah:
+    #     print(f'{l} -> {lah[l]}')
+    return lah
+
+
+lah = {}
 
 with open(output, 'w') as output_file:
     # JSON header
@@ -203,15 +308,19 @@ with open(output, 'w') as output_file:
             f'parsing hartid {hartid} with trace {filename}', file=sys.stderr)
         tot_lines = len(open(filename).readlines())
         with open(filename) as f:
+            all_lines = f.readlines()[args.start:args.end]
+            # offload lookahead
+            if not banshee:
+                lah = offload_lookahead(all_lines)
             if has_progressbar:
                 for lino, line in progressbar.progressbar(
-                        enumerate(f.readlines()[args.start:args.end]),
+                        enumerate(all_lines),
                         max_value=tot_lines):
                     fails += parse_line(line, hartid)
                     lines += 1
             else:
                 for lino, line in enumerate(
-                        f.readlines()[args.start:args.end]):
+                        all_lines):
                     fails += parse_line(line, hartid)
                     lines += 1
             flush(buf, hartid)

--- a/scripts/tracevis.py
+++ b/scripts/tracevis.py
@@ -204,6 +204,10 @@ parser.add_argument(
     help='Disable addr2line caching'
     ' (slow but might give better traces in some cases)')
 parser.add_argument(
+    '--overlap-instructions',
+    action='store_true',
+    help='Lookahead for instruction duration and report their full duration')
+parser.add_argument(
     '-s',
     '--start',
     metavar='<line>',
@@ -229,6 +233,7 @@ use_time = args.time
 banshee = args.banshee
 addr2line = args.addr2line
 cache = not args.no_cache
+lookahead = args.overlap_instructions
 
 print('elf:', elf, file=sys.stderr)
 print('traces:', traces, file=sys.stderr)
@@ -316,7 +321,7 @@ with open(output, 'w') as output_file:
         with open(filename) as f:
             all_lines = f.readlines()[args.start:args.end]
             # offload lookahead
-            if not banshee:
+            if lookahead:
                 lah = offload_lookahead(all_lines)
             if has_progressbar:
                 for lino, line in progressbar.progressbar(


### PR DESCRIPTION
Add some minor fixes for the benchmarking infrastructure. I.e., patch the trace generation and trace visualization to work with hartids in hex and add a caching mechanism to the latter to improve performance.

## Changelog

### Added

### Changed
- Improve parsing speed of tracevis by caching the `addr2line` calls

### Fixed

(Reference to issues, labels, and related merge requests)

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
