### PR TITLE
[software] Fix `conv_2d` kernel to not preload unused values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Increase pending queue in icache
 - Make serial lookup in icache stallable
 - Generalize MemPool to have any number of groups, configured through the `num_groups` parameter
+- Kernel `conv_2d` will not preload unused values anymore
 
 ### Changed
 - Compile verilator and the verilated model with Clang, for a faster compilation time

--- a/software/runtime/xpulp/conv_2d.h
+++ b/software/runtime/xpulp/conv_2d.h
@@ -82,10 +82,10 @@ void conv2d_3x3_unrolled2_i8_rv32im(int8_t const volatile *__restrict__ in,
     elem_10 = in[in_x + (i - 1)];
     elem_11 = in[in_x + (i + 0)];
     elem_12 = in[in_x + (i + 1)];
-    elem_20 = in[2 * in_x + (i - 1)];
-    elem_21 = in[2 * in_x + (i + 0)];
-    elem_22 = in[2 * in_x + (i + 1)];
     for (j = 1; j < in_y - 1; j++) {
+      elem_20 = in[(j + 1) * in_x + (i - 1)];
+      elem_21 = in[(j + 1) * in_x + (i + 0)];
+      elem_22 = in[(j + 1) * in_x + (i + 1)];
       sum = 0;
       sum += elem_00 * k[0];
       sum += elem_01 * k[1];
@@ -103,9 +103,6 @@ void conv2d_3x3_unrolled2_i8_rv32im(int8_t const volatile *__restrict__ in,
       elem_10 = elem_20;
       elem_11 = elem_21;
       elem_12 = elem_22;
-      elem_20 = in[(j + 2) * in_x + (i - 1)];
-      elem_21 = in[(j + 2) * in_x + (i + 0)];
-      elem_22 = in[(j + 2) * in_x + (i + 1)];
 
       out[j * in_x + i] = sum / (int)weight;
     }


### PR DESCRIPTION
## Changelog
### Fixed
- Kernel `conv_2d` will not preload unused values anymore

(Reference to issues, labels, and related merge requests)

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
