### PR TITLE
Control signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Increase the default AXI width
+- Register all control signals at hierarchy boundaries
 
 ## 0.5.0 - 2022-08-03
 

--- a/hardware/deps/snitch/src/snitch_read_only_cache/snitch_read_only_cache.sv
+++ b/hardware/deps/snitch/src/snitch_read_only_cache/snitch_read_only_cache.sv
@@ -85,7 +85,8 @@ module snitch_read_only_cache #(
   axi_resp_t refill_rsp;
 
   index_t slv_aw_select;
-  index_t slv_ar_select;
+  index_t slv_ar_select, slv_ar_select_q;
+  index_t slv_ar_waiting;
   index_t dec_ar;
 
   axi_demux #(
@@ -153,6 +154,9 @@ module snitch_read_only_cache #(
   assign slv_aw_select = Bypass;
 
   // `AR` select logic
+  `FF(slv_ar_select_q, slv_ar_select, Bypass, clk_i, rst_ni)
+  `FF(slv_ar_waiting, axi_slv_req_i.ar_valid && !axi_slv_rsp_o.ar_ready, '0, clk_i, rst_ni)
+
   always_comb begin
     // Select cache based on address region
     slv_ar_select = dec_ar;
@@ -171,6 +175,10 @@ module snitch_read_only_cache #(
     // Bypass cache if disabled
     if (!enable_i) begin
       slv_ar_select = Bypass;
+    end
+    // Keep the select signal stable if the request was not accepted
+    if(slv_ar_waiting) begin
+      slv_ar_select = slv_ar_select_q;
     end
   end
 

--- a/hardware/src/mempool_cc.sv
+++ b/hardware/src/mempool_cc.sv
@@ -207,7 +207,9 @@ module mempool_cc
 
   always_ff @(posedge rst_i) begin
     if(rst_i) begin
-      $sformat(fn, "trace_hart_0x%04x.dasm", hart_id_i);
+      // Format in hex because vcs and vsim treat decimal differently
+      // Format with 8 digits because Verilator does not support anything else
+      $sformat(fn, "trace_hart_0x%08x.dasm", hart_id_i);
       f = $fopen(fn, "w");
       $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
     end

--- a/hardware/src/mempool_cluster.sv
+++ b/hardware/src/mempool_cluster.sv
@@ -39,6 +39,15 @@ module mempool_cluster
   input  axi_tile_resp_t [NumAXIMasters-1:0] axi_mst_resp_i
 );
 
+  /*********************
+   *  Control Signals  *
+   *********************/
+  logic [NumCores-1:0] wake_up_q;
+  `FF(wake_up_q, wake_up_i, '0, clk_i, rst_ni);
+
+  ro_cache_ctrl_t ro_cache_ctrl_q;
+  `FF(ro_cache_ctrl_q, ro_cache_ctrl_i, '0, clk_i, rst_ni);
+
   /*********
    *  DMA  *
    *********/
@@ -153,8 +162,8 @@ module mempool_cluster
       .tcdm_slave_resp_o       (tcdm_slave_resp[g]                                              ),
       .tcdm_slave_resp_valid_o (tcdm_slave_resp_valid[g]                                        ),
       .tcdm_slave_resp_ready_i (tcdm_slave_resp_ready[g]                                        ),
-      .wake_up_i               (wake_up_i[g*NumCoresPerGroup +: NumCoresPerGroup]               ),
-      .ro_cache_ctrl_i         (ro_cache_ctrl_i                                                 ),
+      .wake_up_i               (wake_up_q[g*NumCoresPerGroup +: NumCoresPerGroup]               ),
+      .ro_cache_ctrl_i         (ro_cache_ctrl_q                                                 ),
       // DMA request
       .dma_req_i               (dma_req[g]                                                      ),
       .dma_req_valid_i         (dma_req_valid[g]                                                ),

--- a/hardware/src/mempool_cluster.sv
+++ b/hardware/src/mempool_cluster.sv
@@ -46,7 +46,7 @@ module mempool_cluster
   `FF(wake_up_q, wake_up_i, '0, clk_i, rst_ni);
 
   ro_cache_ctrl_t ro_cache_ctrl_q;
-  `FF(ro_cache_ctrl_q, ro_cache_ctrl_i, '0, clk_i, rst_ni);
+  `FF(ro_cache_ctrl_q, ro_cache_ctrl_i, ro_cache_ctrl_default, clk_i, rst_ni);
 
   /*********
    *  DMA  *

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -67,7 +67,7 @@ module mempool_group
   `FF(wake_up_q, wake_up_i, '0, clk_i, rst_ni);
 
   ro_cache_ctrl_t ro_cache_ctrl_q;
-  `FF(ro_cache_ctrl_q, ro_cache_ctrl_i, '0, clk_i, rst_ni);
+  `FF(ro_cache_ctrl_q, ro_cache_ctrl_i, ro_cache_ctrl_default, clk_i, rst_ni);
 
   /**********************
    *  Ports to structs  *

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -60,6 +60,15 @@ module mempool_group
 
   typedef logic [idx_width(NumTiles)-1:0] tile_id_t;
 
+  /*********************
+   *  Control Signals  *
+   *********************/
+  logic [NumCoresPerGroup-1:0] wake_up_q;
+  `FF(wake_up_q, wake_up_i, '0, clk_i, rst_ni);
+
+  ro_cache_ctrl_t ro_cache_ctrl_q;
+  `FF(ro_cache_ctrl_q, ro_cache_ctrl_i, '0, clk_i, rst_ni);
+
   /**********************
    *  Ports to structs  *
    **********************/
@@ -165,7 +174,7 @@ module mempool_group
       .axi_mst_req_o           (axi_tile_req[t]                                ),
       .axi_mst_resp_i          (axi_tile_resp[t]                               ),
       // Wake up interface
-      .wake_up_i               (wake_up_i[t*NumCoresPerTile +: NumCoresPerTile])
+      .wake_up_i               (wake_up_q[t*NumCoresPerTile +: NumCoresPerTile])
     );
 
     // Transpose the group requests
@@ -390,7 +399,7 @@ module mempool_group
     .clk_i           (clk_i                       ),
     .rst_ni          (rst_ni                      ),
     .test_i          (1'b0                        ),
-    .ro_cache_ctrl_i (ro_cache_ctrl_i             ),
+    .ro_cache_ctrl_i (ro_cache_ctrl_q             ),
     .slv_req_i       ({axi_dma_req,axi_tile_req}  ),
     .slv_resp_o      ({axi_dma_resp,axi_tile_resp}),
     .mst_req_o       (axi_mst_req                 ),

--- a/hardware/src/mempool_pkg.sv
+++ b/hardware/src/mempool_pkg.sv
@@ -152,6 +152,14 @@ package mempool_pkg;
     logic [ROCacheNumAddrRules-1:0][AddrWidth-1:0] end_addr;
   } ro_cache_ctrl_t;
 
+  // RO cache reset value to avoid fatal warnings during reset in the address decoder
+  localparam ro_cache_ctrl_t ro_cache_ctrl_default = '{
+    enable: '0,
+    flush_valid: '0,
+    start_addr: {32'h18,32'h10,32'h08,32'h00},
+    end_addr: {32'h1C,32'h14,32'h0C,32'h04}
+  };
+
   /*********
    *  DMA  *
    *********/

--- a/hardware/src/mempool_tile.sv
+++ b/hardware/src/mempool_tile.sv
@@ -71,6 +71,12 @@ module mempool_tile
   // Local interconnect address width
   typedef logic [idx_width(NumCoresPerTile + NumGroups)-1:0] local_req_interco_addr_t;
 
+  /*********************
+   *  Control Signals  *
+   *********************/
+  logic [NumCoresPerTile-1:0] wake_up_q;
+  `FF(wake_up_q, wake_up_i, '0, clk_i, rst_ni);
+
   // Group ID
   logic [idx_width(NumGroups)-1:0] group_id;
   if (NumGroups != 1) begin: gen_group_id
@@ -134,7 +140,7 @@ module mempool_tile
         .data_pid_i    (snitch_data_pid[c]                                       ),
         .data_pvalid_i (snitch_data_pvalid[c]                                    ),
         .data_pready_o (snitch_data_pready[c]                                    ),
-        .wake_up_sync_i(wake_up_i[c]                                             ),
+        .wake_up_sync_i(wake_up_q[c]                                             ),
         // Core Events
         .core_events_o (/* Unused */                                             )
       );

--- a/hardware/tb/verilator/mempool_main/mempool_tb_verilator.cc
+++ b/hardware/tb/verilator/mempool_main/mempool_tb_verilator.cc
@@ -44,8 +44,8 @@ int main(int argc, char **argv) {
   simctrl.RegisterExtension(&memutil);
 #endif
 
-  simctrl.SetInitialResetDelay(5);
-  simctrl.SetResetDuration(5);
+  simctrl.SetInitialResetDelay(1);
+  simctrl.SetResetDuration(4);
 
   bool exit_app = false;
   int ret_code = simctrl.ParseCommandArgs(argc, argv, exit_app);


### PR DESCRIPTION
Add registers for control signals at hierarchy boundaries. This also fixes a small bug in the RO cache, which was exposed by the additional latency of the control signals.

## Changelog

### Changed
- Register all control signals at hierarchy boundaries

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed