### PR TITLE
Parametrization fixes to systolic queues software implementation

### DIFF
--- a/config/mempool.mk
+++ b/config/mempool.mk
@@ -17,6 +17,9 @@ num_groups ?= 4
 # Number of cores per MemPool tile
 num_cores_per_tile ?= 4
 
+# L1 scratchpad banking factor
+banking_factor ?= 4
+
 # Radix for hierarchical AXI interconnect
 axi_hier_radix ?= 20
 

--- a/config/minpool.mk
+++ b/config/minpool.mk
@@ -17,6 +17,9 @@ num_groups ?= 4
 # Number of cores per MemPool tile
 num_cores_per_tile ?= 4
 
+# L1 scratchpad banking factor
+banking_factor ?= 4
+
 # Number of DMA backends in each group
 dmas_per_group ?= 1
 

--- a/config/systolic.mk
+++ b/config/systolic.mk
@@ -15,6 +15,9 @@ num_groups ?= 4
 # Number of cores per MemPool tile
 num_cores_per_tile ?= 4
 
+# L1 scratchpad banking factor
+banking_factor ?= 4
+
 # Radix for hierarchical AXI interconnect
 axi_hier_radix ?= 16
 

--- a/config/systolic.mk
+++ b/config/systolic.mk
@@ -29,6 +29,6 @@ seq_mem_size ?= 2048
 ##  Xqueues configuration  ##
 #############################
 
-# XQueue extension's queue size in each memory bank (in words)
-# (assume banking factor of 4)
+# Xqueue extension's queue size (in queue entries)
+# in each memory bank (assume banking factor of 4)
 xqueue_size ?= 4

--- a/config/terapool.mk
+++ b/config/terapool.mk
@@ -17,6 +17,9 @@ num_groups ?= 8
 # Number of cores per Terapool tile
 num_cores_per_tile ?= 8
 
+# L1 scratchpad banking factor
+banking_factor ?= 4
+
 # Radix for hierarchical AXI interconnect
 axi_hier_radix ?= 8
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -87,7 +87,7 @@ endif
 vlog_args += -suppress vlog-2583 -suppress vlog-13314 -suppress vlog-13233
 vlog_args += -work $(library)
 # Defines
-vlog_defs += -DNUM_CORES=$(num_cores) -DNUM_CORES_PER_TILE=$(num_cores_per_tile) -DNUM_GROUPS=$(num_groups)
+vlog_defs += -DNUM_CORES=$(num_cores) -DNUM_CORES_PER_TILE=$(num_cores_per_tile) -DNUM_GROUPS=$(num_groups) -DBANKING_FACTOR=$(banking_factor)
 vlog_defs += -DL2_BASE=$(l2_base) -DL2_SIZE=$(l2_size) -DL2_BANKS=$(l2_banks)
 vlog_defs += -DBOOT_ADDR=$(boot_addr) -DXPULPIMG=$(xpulpimg)
 vlog_defs += -DSNITCH_TRACE=$(snitch_trace)

--- a/hardware/src/mempool_pkg.sv
+++ b/hardware/src/mempool_pkg.sv
@@ -35,7 +35,7 @@ package mempool_pkg;
   localparam integer unsigned DataWidth        = 32;
   localparam integer unsigned BeWidth          = DataWidth / 8;
   localparam integer unsigned ByteOffset       = $clog2(BeWidth);
-  localparam integer unsigned BankingFactor    = 4;
+  localparam integer unsigned BankingFactor    = `ifdef BANKING_FACTOR `BANKING_FACTOR `else 0 `endif;
   localparam bit              LrScEnable       = 1'b1;
   localparam integer unsigned TCDMSizePerBank  = 1024; // [B]
   localparam integer unsigned NumBanks         = NumCores * BankingFactor;

--- a/software/apps/memcpy/main.c
+++ b/software/apps/memcpy/main.c
@@ -27,7 +27,7 @@
 #ifndef SIZE
 #define SIZE ((NUM_CORES) * (NUM_CORES)*2)
 #endif
-#define BANKING_FACTOR (4)
+// Assume banking factor of 4
 
 uint32_t l2_data_a[SIZE] __attribute__((section(".l2")))
 __attribute__((aligned(NUM_CORES * 4 * 4)));

--- a/software/apps/systolic/matmul/main.c
+++ b/software/apps/systolic/matmul/main.c
@@ -32,7 +32,8 @@ systolic_matrix_t *syst_matrix_C;
 
 void generate_gradient_matrix(int32_t **matrix, uint32_t num_rows,
                               uint32_t num_cols) {
-  int32_t *new_matrix = (int32_t *)simple_malloc(num_rows * num_cols * 4);
+  int32_t *new_matrix =
+      (int32_t *)simple_malloc(num_rows * num_cols * sizeof(int32_t));
   for (uint32_t y = 0; y < num_rows; ++y) {
     for (uint32_t x = 0; x < num_cols; ++x) {
       new_matrix[y * num_cols + x] = (int32_t)(y + x);
@@ -55,7 +56,7 @@ void print_matrix(int32_t const *matrix, uint32_t num_rows,
 int main() {
   uint32_t core_id = mempool_get_core_id();
   uint32_t num_cores = mempool_get_core_count();
-  uint32_t tile_id = core_id / 4;
+  uint32_t tile_id = core_id / NUM_CORES_PER_TILE;
 
   // Initialize synchronization variables
   mempool_barrier_init(core_id);
@@ -65,7 +66,7 @@ int main() {
 
   // Allocate systolic grid mapping
   if (core_id == 0) {
-    grid_mapping = (uint32_t *)simple_malloc(num_cores * 4);
+    grid_mapping = (uint32_t *)simple_malloc(num_cores * sizeof(uint32_t));
     if (num_cores != SYSTOLIC_SIZE * SYSTOLIC_SIZE) {
       printf("SYSTOLIC_SIZE does not match core count!\n");
       return -1;

--- a/software/apps/systolic/queue_multi_test/main.c
+++ b/software/apps/systolic/queue_multi_test/main.c
@@ -47,17 +47,17 @@ int main() {
 
   // Producer
   if (core_id == 0) {
-    int32_t data[4];
+    int32_t data[DATA_SIZE];
     uint32_t counter = 0;
-    for (uint32_t i = 0; i < 8; ++i) {
-      for (uint32_t j = 0; j < 4; ++j) {
-        data[j] = (int32_t)(i * 4 + j);
+    for (uint32_t i = 0; i < XQUEUE_SIZE * 2; ++i) {
+      for (uint32_t j = 0; j < DATA_SIZE; ++j) {
+        data[j] = (int32_t)(i * DATA_SIZE + j);
       }
       blocking_queue_push(queue, data);
     }
-    for (uint32_t i = 0; i < 8; ++i) {
-      for (uint32_t j = 0; j < 4; ++j) {
-        data[j] = (int32_t)(i * 4 + j);
+    for (uint32_t i = 0; i < XQUEUE_SIZE * 2; ++i) {
+      for (uint32_t j = 0; j < DATA_SIZE; ++j) {
+        data[j] = (int32_t)(i * DATA_SIZE + j);
       }
       counting_queue_push(queue, data, &counter);
     }
@@ -66,17 +66,17 @@ int main() {
 
   // Consumer
   if (core_id == 1) {
-    int32_t read_data[4];
+    int32_t read_data[DATA_SIZE];
     uint32_t counter = 0;
-    for (uint32_t i = 0; i < 8; ++i) {
+    for (uint32_t i = 0; i < XQUEUE_SIZE * 2; ++i) {
       blocking_queue_pop(queue, read_data);
-      for (uint32_t j = 0; j < 4; ++j) {
+      for (uint32_t j = 0; j < DATA_SIZE; ++j) {
         printf("Rx: %d\n", read_data[j]);
       }
     }
-    for (uint32_t i = 0; i < 8; ++i) {
+    for (uint32_t i = 0; i < XQUEUE_SIZE * 2; ++i) {
       counting_queue_pop(queue, read_data, &counter);
-      for (uint32_t j = 0; j < 4; ++j) {
+      for (uint32_t j = 0; j < DATA_SIZE; ++j) {
         printf("Rx: %d\n", read_data[j]);
       }
     }

--- a/software/apps/systolic/queue_test/main.c
+++ b/software/apps/systolic/queue_test/main.c
@@ -14,6 +14,8 @@
 #include "synchronization.h"
 #include "systolic/queue.h"
 
+#define QUEUE_ENTRIES 8
+
 queue_t *queue = 0;
 
 uint32_t producer_cnt;
@@ -34,7 +36,7 @@ int main() {
     printf("Initialize\n");
 
     // Create queue
-    queue_create(&queue, 8);
+    queue_create(&queue, QUEUE_ENTRIES);
   }
 
   // Wait for all cores
@@ -42,12 +44,13 @@ int main() {
 
   // Producer
   if (core_id == 0) {
-    int32_t data[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    int32_t data[QUEUE_ENTRIES * 2] = {0, 1, 2,  3,  4,  5,  6,  7,
+                                       8, 9, 10, 11, 12, 13, 14, 15};
     uint32_t counter = 0;
-    for (uint32_t i = 0; i < 16; ++i) {
+    for (uint32_t i = 0; i < QUEUE_ENTRIES * 2; ++i) {
       blocking_queue_push(queue, &data[i]);
     }
-    for (uint32_t i = 0; i < 16; ++i) {
+    for (uint32_t i = 0; i < QUEUE_ENTRIES * 2; ++i) {
       counting_queue_push(queue, &data[i], &counter);
     }
     producer_cnt = counter;
@@ -57,11 +60,11 @@ int main() {
   if (core_id == 1) {
     int32_t read_data;
     uint32_t counter = 0;
-    for (uint32_t i = 0; i < 16; ++i) {
+    for (uint32_t i = 0; i < QUEUE_ENTRIES * 2; ++i) {
       blocking_queue_pop(queue, &read_data);
       printf("Rx: %d\n", read_data);
     }
-    for (uint32_t i = 0; i < 16; ++i) {
+    for (uint32_t i = 0; i < QUEUE_ENTRIES * 2; ++i) {
       counting_queue_pop(queue, &read_data, &counter);
       printf("Rx: %d\n", read_data);
     }

--- a/software/runtime/runtime.h
+++ b/software/runtime/runtime.h
@@ -11,6 +11,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define NUM_BANKS_PER_TILE NUM_CORES_PER_TILE *BANKING_FACTOR
+
 extern char l1_alloc_base;
 extern uint32_t atomic_barrier;
 extern volatile uint32_t wake_up_reg;

--- a/software/runtime/runtime.h
+++ b/software/runtime/runtime.h
@@ -49,13 +49,16 @@ static inline void mempool_init(const uint32_t core_id,
 
     // Initialize L1 Sequential Heap Allocator per Tile
     extern int32_t __seq_start;
-    uint32_t seq_heap_offset = 4 * STACK_SIZE + 16 * 4 * XQUEUE_SIZE;
-    uint32_t seq_total_size = 4 * SEQ_MEM_SIZE;
-    int32_t *seq_heap_base = &__seq_start + (seq_heap_offset / 4);
+    uint32_t seq_heap_offset =
+        NUM_CORES_PER_TILE * STACK_SIZE +
+        NUM_BANKS_PER_TILE * sizeof(int32_t) * XQUEUE_SIZE;
+    uint32_t seq_total_size = NUM_CORES_PER_TILE * SEQ_MEM_SIZE;
+    int32_t *seq_heap_base = &__seq_start + (seq_heap_offset / sizeof(int32_t));
     uint32_t seq_heap_size = seq_total_size - seq_heap_offset;
-    for (uint32_t tile_id = 0; tile_id < num_cores / 4; ++tile_id) {
+    for (uint32_t tile_id = 0; tile_id < num_cores / NUM_CORES_PER_TILE;
+         ++tile_id) {
       alloc_init(get_alloc_tile(tile_id), seq_heap_base, seq_heap_size);
-      seq_heap_base += (seq_total_size / 4);
+      seq_heap_base += (seq_total_size / sizeof(int32_t));
     }
   }
 }

--- a/software/runtime/runtime.mk
+++ b/software/runtime/runtime.mk
@@ -64,6 +64,7 @@ DEFINES += -DPRINTF_DISABLE_SUPPORT_FLOAT -DPRINTF_DISABLE_SUPPORT_LONG_LONG -DP
 DEFINES += -DNUM_CORES=$(num_cores)
 DEFINES += -DNUM_GROUPS=$(num_groups)
 DEFINES += -DNUM_CORES_PER_TILE=$(num_cores_per_tile)
+DEFINES += -DBANKING_FACTOR=$(banking_factor)
 DEFINES += -DNUM_CORES_PER_GROUP=$(shell awk 'BEGIN{print $(num_cores)/$(num_groups)}')
 DEFINES += -DNUM_TILES_PER_GROUP=$(shell awk 'BEGIN{print ($(num_cores)/$(num_groups))/$(num_cores_per_tile)}')
 DEFINES += -DLOG2_NUM_CORES_PER_TILE=$(shell awk 'BEGIN{print log($(num_cores_per_tile))/log(2)}')

--- a/software/runtime/systolic/matmul.h
+++ b/software/runtime/systolic/matmul.h
@@ -17,11 +17,13 @@
 #include "printf.h"
 #include "systolic/queue_multi.h"
 
-// Dimensions of square systolic array
-// TODO: SQRT ROOT OF NUM_CORES FOR SYSTOLIC SIZE
-#define SYSTOLIC_SIZE 16
-
 // IMPORTANT: DATA_SIZE of queue_multi.h must be set to 4
+#if DATA_SIZE == 4 && NUM_CORES == 256
+
+// Dimensions of square systolic array
+// TODO: SYSTOLIC_SIZE must be sqrt of NUM_CORES; for now hardcoded for 256
+// cores
+#define SYSTOLIC_SIZE 16
 
 // Systolic matrix
 typedef struct {
@@ -76,10 +78,12 @@ void systolic_matrix_allocate(systolic_matrix_t **syst_matrix,
   uint32_t syst_num_cols = (uint32_t)((num_cols + 1) & 0xFFFE);
 
   // Allocate matrix array
-  int32_t *array = (int32_t *)simple_malloc(syst_num_rows * syst_num_cols * 4);
+  int32_t *array =
+      (int32_t *)simple_malloc(syst_num_rows * syst_num_cols * sizeof(int32_t));
 
   // Allocate systolic matrix
-  systolic_matrix_t *new_matrix = (systolic_matrix_t *)simple_malloc(3 * 4);
+  systolic_matrix_t *new_matrix =
+      (systolic_matrix_t *)simple_malloc(sizeof(systolic_matrix_t));
 
   // Assign values to systolic matrix
   new_matrix->matrix = array;
@@ -96,7 +100,8 @@ void systolic_matrix_create(systolic_matrix_t **syst_matrix, int32_t *matrix,
   uint32_t syst_num_cols = (uint32_t)((num_cols + 1) & 0xFFFE);
 
   // Allocate matrix array
-  int32_t *array = (int32_t *)simple_malloc(syst_num_rows * syst_num_cols * 4);
+  int32_t *array =
+      (int32_t *)simple_malloc(syst_num_rows * syst_num_cols * sizeof(int32_t));
 
   // Copy data into new matrix array
   for (uint32_t y = 0; y < num_rows; ++y) {
@@ -118,7 +123,8 @@ void systolic_matrix_create(systolic_matrix_t **syst_matrix, int32_t *matrix,
   }
 
   // Allocate systolic matrix
-  systolic_matrix_t *new_matrix = (systolic_matrix_t *)simple_malloc(3 * 4);
+  systolic_matrix_t *new_matrix =
+      (systolic_matrix_t *)simple_malloc(sizeof(systolic_matrix_t));
 
   // Assign values to systolic matrix
   new_matrix->matrix = array;
@@ -180,8 +186,8 @@ void systolic_rcp_pe(const uint32_t rep_count,
                      systolic_matrix_t const *__restrict__ C) {
   queue_t *queue_next_horz;
   queue_t *queue_next_vert;
-  int32_t data_horz[4];
-  int32_t data_vert[4];
+  int32_t data_horz[DATA_SIZE];
+  int32_t data_vert[DATA_SIZE];
   int32_t *matrix_A;
   int32_t *matrix_B;
   int32_t *matrix_C;
@@ -275,8 +281,8 @@ void systolic_cp_pe(const uint32_t col_idx, const uint32_t rep_count,
   queue_t *queue_prev_horz;
   queue_t *queue_next_horz;
   queue_t *queue_next_vert;
-  int32_t data_horz[4];
-  int32_t data_vert[4];
+  int32_t data_horz[DATA_SIZE];
+  int32_t data_vert[DATA_SIZE];
   int32_t *matrix_B;
   int32_t *matrix_C;
   uint32_t num_cols_B;
@@ -392,8 +398,8 @@ void systolic_rp_pe(const uint32_t row_idx, const uint32_t rep_count,
   queue_t *queue_next_horz;
   queue_t *queue_prev_vert;
   queue_t *queue_next_vert;
-  int32_t data_horz[4];
-  int32_t data_vert[4];
+  int32_t data_horz[DATA_SIZE];
+  int32_t data_vert[DATA_SIZE];
   int32_t *matrix_A;
   int32_t *matrix_C;
   uint32_t num_cols_A;
@@ -510,8 +516,8 @@ void systolic_np_pe(const uint32_t row_idx, const uint32_t col_idx,
   queue_t *queue_next_horz;
   queue_t *queue_prev_vert;
   queue_t *queue_next_vert;
-  int32_t data_horz[4];
-  int32_t data_vert[4];
+  int32_t data_horz[DATA_SIZE];
+  int32_t data_vert[DATA_SIZE];
   int32_t *matrix_C;
   uint32_t num_rows_C;
   uint32_t num_cols_C;
@@ -630,3 +636,7 @@ void systolic_np_pe(const uint32_t row_idx, const uint32_t col_idx,
   dump_horz_push(h_push_cnt);
   dump_vert_push(v_push_cnt);
 }
+
+#else
+#error Unsupported queue DATA_SIZE or NUM_CORES
+#endif // if DATA_SIZE == 4 && NUM_CORES == 256

--- a/software/runtime/systolic/queue.h
+++ b/software/runtime/systolic/queue.h
@@ -21,8 +21,8 @@ typedef struct {
 } queue_t;
 
 void queue_domain_create(alloc_t *alloc, queue_t **queue, const uint32_t size) {
-  queue_t *new_queue = (queue_t *)domain_malloc(alloc, 4 * 4);
-  int32_t *array = (int32_t *)domain_malloc(alloc, size * 4);
+  queue_t *new_queue = (queue_t *)domain_malloc(alloc, sizeof(queue_t));
+  int32_t *array = (int32_t *)domain_malloc(alloc, size * sizeof(int32_t));
   new_queue->array = array;
   new_queue->head = 0;
   new_queue->tail = 0;

--- a/software/runtime/systolic/queue_multi.h
+++ b/software/runtime/systolic/queue_multi.h
@@ -13,7 +13,7 @@
 #include "alloc.h"
 #include "runtime.h"
 
-#define DATA_SIZE 4
+#define DATA_SIZE 4 // number of words in a queue entry
 
 typedef struct {
   int32_t *buffer;
@@ -23,9 +23,9 @@ typedef struct {
 } queue_t;
 
 void queue_domain_create(alloc_t *alloc, queue_t **queue) {
-  queue_t *new_queue = (queue_t *)domain_malloc(alloc, 4 * 4);
-  int32_t *buffer =
-      (int32_t *)domain_malloc(alloc, XQUEUE_SIZE * DATA_SIZE * 4);
+  queue_t *new_queue = (queue_t *)domain_malloc(alloc, sizeof(queue_t));
+  int32_t *buffer = (int32_t *)domain_malloc(alloc, XQUEUE_SIZE * DATA_SIZE *
+                                                        sizeof(int32_t));
   new_queue->buffer = buffer;
   new_queue->head = 0;
   new_queue->tail = 0;


### PR DESCRIPTION
Fix parametrization of runtime functions (including memory allocation, queue management library, systolic matmul library) and systolic queue software examples. These fixes add on top of https://github.com/pulp-platform/mempool/pull/34, making the systolic software implementation more readable and self-explanatory.

## Changelog
- Improved comments
- Removed hardcoded constants and parametrized with config-defined macros and compiler directives

in:

- systolic config file
- software systolic queue libraries and apps examples
- systolic matmul library and app example
- dynamic memory allocation library

## Checklist
- [x] Finish to parameterize matmul library + app
- [x] Finish to parametrize dynamic memory allocation library + app
- [x] Fix CI
- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

## Future improvement
- Software systolic matmul is hardcoded to only support `DATA_SIZE == 4 && NUM_CORES == 256`
- Solve TODOs in dynamic memory allocation library `alloc.c`
- Fix hardcoded stuff realted to heap initialization in `runtime.h:mempool_init()`