### PR TITLE
[software] Correct condition on sub-tile wake-up

### DIFF
--- a/software/runtime/synchronization.c
+++ b/software/runtime/synchronization.c
@@ -100,7 +100,7 @@ void mempool_log_partial_barrier(uint32_t step, uint32_t core_id,
                        ((1U << (tile_end - tile_init)) - 1)
                            << tile_init % NUM_TILES_PER_GROUP);
         } else {
-          while (core_init > core_end - 1) {
+          while (core_init < core_end) {
             wake_up(core_init);
             core_init++;
           }


### PR DESCRIPTION
Correct condition on sub-tile wake-up

## Changelog

### Changed
Correct condition on sub-tile wake-up in software/runtime/synchronization.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
