### PR TITLE
Pack2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Add a DMA
+- Add pv.pack.h xpulpv2 instruction
 
 ### Fixed
 - Measure the `wfi` stalls and stalls caused by `opc` properly

--- a/hardware/deps/snitch/src/snitch.sv
+++ b/hardware/deps/snitch/src/snitch.sv
@@ -1309,7 +1309,8 @@ module snitch
       riscv_instr::PV_SDOTSP_B,          // Xpulpimg: pv.sdotsp.b
       riscv_instr::PV_SDOTSP_SC_B,       // Xpulpimg: pv.sdotsp.sc.b
       riscv_instr::PV_SHUFFLE2_H,        // Xpulpimg: pv.shuffle2.h
-      riscv_instr::PV_SHUFFLE2_B: begin  // Xpulpimg: pv.shuffle2.b
+      riscv_instr::PV_SHUFFLE2_B,        // Xpulpimg: pv.shuffle2.b
+      riscv_instr::PV_PACK_H: begin      // Xpulpimg: pv.pack.h
         if (snitch_pkg::XPULPIMG) begin
           write_rd = 1'b0;
           uses_rd = 1'b1;

--- a/hardware/deps/snitch/src/snitch_ipu.sv
+++ b/hardware/deps/snitch/src/snitch_ipu.sv
@@ -1445,8 +1445,8 @@ module dspu #(
               simd_result[2*i +: 2] = simd_op_b[2*i][1] ? simd_op_a[2*simd_op_b[2*i][0] +: 2] : simd_op_c[2*simd_op_b[2*i][0] +: 2];
             end
           SimdPack: begin
-            simd_result[3:2] = op_a_i[1:0];
-            simd_result[1:0] = op_b_i[1:0];
+            simd_result[3:2] = simd_op_a[1:0];
+            simd_result[1:0] = simd_op_b[1:0];
           end
           default: ;
         endcase

--- a/software/riscv-tests/isa/rv32uxpulpimg/pv_pack.S
+++ b/software/riscv-tests/isa/rv32uxpulpimg/pv_pack.S
@@ -1,0 +1,59 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# pv_pack.S
+#-----------------------------------------------------------------------------
+#
+# Test pv.pack instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  # pv.pack.h
+  TEST_RR_OP(  2, pv.pack.h, 0x3F6E26D0, 0x00003F6E, 0x000026D0 );
+  TEST_RR_OP(  3, pv.pack.h, 0x07067322, 0x511B0706, 0xEB397322 );
+  TEST_RR_OP(  4, pv.pack.h, 0x15F2278E, 0x9D2D15F2, 0x5C71278E );
+  TEST_RR_OP(  5, pv.pack.h, 0xD28E7E80, 0x2C48AA34, 0x4887D28E );
+  TEST_RR_OP(  6, pv.pack.h, 0xD68F4961, 0xADE8E999, 0xD26AD68F );
+  TEST_RR_OP(  7, pv.pack.h, 0xAF791495, 0x6BF30059, 0xEFB6AF79 );
+  TEST_RR_OP(  8, pv.pack.h, 0x1058A035, 0xB7FED864, 0x5BBB1058 );
+  TEST_RR_OP(  9, pv.pack.h, 0xCF23A53E, 0xFDC2EA55, 0x7292CF23 );
+  TEST_RR_OP( 10, pv.pack.h, 0x060F3B63, 0x32CBBE72, 0x6DB6060F );
+  TEST_RR_OP( 11, pv.pack.h, 0xDD224389, 0xCB19A2A3, 0x00BCDD22 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  # TODO(smazzola):
+  # for reg-reg-reg instructions TEST_RRR_SRC1_EQ_DEST,
+  # TEST_RRR_SRC2_EQ_DEST, TEST_RRR_SRC12_EQ_DEST
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  # TODO(smazzola):
+  # for reg-reg-reg instructions TEST_RRR_DEST_BYPASS,
+  # TEST_RRR_SRC12_BYPASS, TEST_RRR_SRC21_BYPASS, TEST_RRR_SRC3_BYPASS,
+  # TEST_RRR_ZEROSRC1, TEST_RRR_ZEROSRC2, TEST_RRR_ZEROSRC3,
+  # TEST_RRR_ZEROSRC12, TEST_RRR_ZEROSRC123, TEST_RRR_ZERODEST
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/software/runtime/xpulp/builtins_v2.h
+++ b/software/runtime/xpulp/builtins_v2.h
@@ -13,7 +13,15 @@ typedef signed char v4s __attribute__((vector_size(4)));
 typedef unsigned char v4u __attribute__((vector_size(4)));
 
 /* Packing of scalars into vectors */
-#define __PACK2(x, y) __builtin_pulp_pack2((signed short)(x), (signed short)(y))
+
+inline v2s __PACK2(const int32_t x, const int32_t y) {
+  v2s output;
+  asm volatile("pv.pack.h %[z], %[x], %[y];"
+               : [z] "=r"(output)
+               : [x] "r"(x), [y] "r"(y));
+  return output;
+}
+
 #define __PACKU2(x, y)                                                         \
   __builtin_pulp_pack2((unsigned short)(x), (unsigned short)(y))
 

--- a/toolchain/riscv-isa-sim/disasm/disasm.cc
+++ b/toolchain/riscv-isa-sim/disasm/disasm.cc
@@ -1514,6 +1514,7 @@ disassembler_t::disassembler_t(int xlen)
 
   DEFINE_RTYPE(pv_shuffle2_h);
   DEFINE_RTYPE(pv_shuffle2_b);
+  DEFINE_RTYPE(pv_pack_h);
 
   // provide a default disassembly for all instructions as a fallback
   #define DECLARE_INSN(code, match, mask) \

--- a/toolchain/riscv-isa-sim/riscv/insns/pv_pack_h.h
+++ b/toolchain/riscv-isa-sim/riscv/insns/pv_pack_h.h
@@ -1,0 +1,5 @@
+uint32_t ins_rd = RD;
+
+ins_rd = ((RS1_H(0) & 0xFFFF) << (xlen >> 1)) | ((uint32_t)(RS1_H(0)) & 0x0000FFFF);
+
+WRITE_RD(sext_xlen(ins_rd));

--- a/toolchain/riscv-isa-sim/riscv/riscv.mk.in
+++ b/toolchain/riscv-isa-sim/riscv/riscv.mk.in
@@ -932,6 +932,7 @@ riscv_insn_ext_xpulpimg = \
 	pv_sdotsp_sci_b \
 	pv_shuffle2_h \
 	pv_shuffle2_b \
+	pv_pack_h \
 
 riscv_insn_ext_h = \
 	hfence_gvma \


### PR DESCRIPTION
Add pack2 xpulpv2 extension

## Changelog

### Added
xpulpv2 pack2 extension is added to Snitch IPU. The instruction packs the 16 least significant bits of the input operands in the 32 bit output.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
