### PR TITLE
Pack2

### DIFF
--- a/hardware/deps/snitch/src/snitch.sv
+++ b/hardware/deps/snitch/src/snitch.sv
@@ -1320,6 +1320,7 @@ module snitch
       riscv_instr::PV_SDOTSP_SC_B,       // Xpulpimg: pv.sdotsp.sc.b
       riscv_instr::PV_SHUFFLE2_H,        // Xpulpimg: pv.shuffle2.h
       riscv_instr::PV_SHUFFLE2_B,        // Xpulpimg: pv.shuffle2.b
+      riscv_instr::PV_PACK,              // Xpulpimg: pv.pack
       riscv_instr::PV_PACK_H: begin      // Xpulpimg: pv.pack.h
         if (snitch_pkg::XPULPIMG) begin
           write_rd = 1'b0;

--- a/software/riscv-tests/isa/rv32uxpulpimg/Makefrag
+++ b/software/riscv-tests/isa/rv32uxpulpimg/Makefrag
@@ -36,6 +36,7 @@ rv32uxpulpimg_sc_tests = \
   pv_dotup \
   pv_dotusp \
   pv_dotsp \
+  pv_pack \
   pv_sdotup \
   pv_sdotusp \
   pv_sdotsp \

--- a/software/riscv-tests/isa/rv32uxpulpimg/pv_pack.S
+++ b/software/riscv-tests/isa/rv32uxpulpimg/pv_pack.S
@@ -21,13 +21,13 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP(  2, pv.pack.h, 0x3F6E26D0, 0x00003F6E, 0x000026D0 );
   TEST_RR_OP(  3, pv.pack.h, 0x07067322, 0x511B0706, 0xEB397322 );
   TEST_RR_OP(  4, pv.pack.h, 0x15F2278E, 0x9D2D15F2, 0x5C71278E );
-  TEST_RR_OP(  5, pv.pack.h, 0xD28E7E80, 0x2C48AA34, 0x4887D28E );
-  TEST_RR_OP(  6, pv.pack.h, 0xD68F4961, 0xADE8E999, 0xD26AD68F );
-  TEST_RR_OP(  7, pv.pack.h, 0xAF791495, 0x6BF30059, 0xEFB6AF79 );
-  TEST_RR_OP(  8, pv.pack.h, 0x1058A035, 0xB7FED864, 0x5BBB1058 );
-  TEST_RR_OP(  9, pv.pack.h, 0xCF23A53E, 0xFDC2EA55, 0x7292CF23 );
-  TEST_RR_OP( 10, pv.pack.h, 0x060F3B63, 0x32CBBE72, 0x6DB6060F );
-  TEST_RR_OP( 11, pv.pack.h, 0xDD224389, 0xCB19A2A3, 0x00BCDD22 );
+  TEST_RR_OP(  5, pv.pack.h, 0xD28E7E80, 0x4887D28E, 0x2C487E80 );
+  TEST_RR_OP(  6, pv.pack.h, 0xE999D68F, 0xADE8E999, 0xD26AD68F );
+  TEST_RR_OP(  7, pv.pack.h, 0xAF790059, 0xEFB6AF79, 0x6BF30059 );
+  TEST_RR_OP(  8, pv.pack.h, 0x1058D864, 0x5BBB1058, 0xB7FED864 );
+  TEST_RR_OP(  9, pv.pack.h, 0xCF23EA55, 0x7292CF23, 0xFDC2EA55 );
+  TEST_RR_OP( 10, pv.pack.h, 0xBE72060F, 0x32CBBE72, 0x6DB6060F );
+  TEST_RR_OP( 11, pv.pack.h, 0xA2A3DD22, 0xCB19A2A3, 0x00BCDD22 );
 
   #-------------------------------------------------------------
   # Source/Destination tests

--- a/software/riscv-tests/isa/rv32uxpulpimg/pv_pack_h.S
+++ b/software/riscv-tests/isa/rv32uxpulpimg/pv_pack_h.S
@@ -1,7 +1,7 @@
 # See LICENSE for license details.
 
 #*****************************************************************************
-# pv_pack_h.S
+# pv_pack.S
 #-----------------------------------------------------------------------------
 #
 # Test pv.pack instructions.
@@ -17,17 +17,17 @@ RVTEST_CODE_BEGIN
   # Arithmetic tests
   #-------------------------------------------------------------
 
-  # pv.pack
-  TEST_RR_OP(  2, pv.pack, 0x3F6E26D0, 0x00003F6E, 0x000026D0 );
-  TEST_RR_OP(  3, pv.pack, 0x07067322, 0x511B0706, 0xEB397322 );
-  TEST_RR_OP(  4, pv.pack, 0x15F2278E, 0x9D2D15F2, 0x5C71278E );
-  TEST_RR_OP(  5, pv.pack, 0xD28E7E80, 0x4887D28E, 0x2C487E80 );
-  TEST_RR_OP(  6, pv.pack, 0xE999D68F, 0xADE8E999, 0xD26AD68F );
-  TEST_RR_OP(  7, pv.pack, 0xAF790059, 0xEFB6AF79, 0x6BF30059 );
-  TEST_RR_OP(  8, pv.pack, 0x1058D864, 0x5BBB1058, 0xB7FED864 );
-  TEST_RR_OP(  9, pv.pack, 0xCF23EA55, 0x7292CF23, 0xFDC2EA55 );
-  TEST_RR_OP( 10, pv.pack, 0xBE72060F, 0x32CBBE72, 0x6DB6060F );
-  TEST_RR_OP( 11, pv.pack, 0xA2A3DD22, 0xCB19A2A3, 0x00BCDD22 );
+  # pv.pack.h
+  TEST_RR_OP(  2, pv.pack.h, 0x00000000, 0x00003F6E, 0x000026D0 );
+  TEST_RR_OP(  3, pv.pack.h, 0x511BEB39, 0x511B0706, 0xEB397322 );
+  TEST_RR_OP(  4, pv.pack.h, 0x9D2D5C71, 0x9D2D15F2, 0x5C71278E );
+  TEST_RR_OP(  5, pv.pack.h, 0x48872C48, 0x4887D28E, 0x2C487E80 );
+  TEST_RR_OP(  6, pv.pack.h, 0xADE8D26A, 0xADE8E999, 0xD26AD68F );
+  TEST_RR_OP(  7, pv.pack.h, 0xEFB66BF3, 0xEFB6AF79, 0x6BF30059 );
+  TEST_RR_OP(  8, pv.pack.h, 0x5BBBB7FE, 0x5BBB1058, 0xB7FED864 );
+  TEST_RR_OP(  9, pv.pack.h, 0x7292FDC2, 0x7292CF23, 0xFDC2EA55 );
+  TEST_RR_OP( 10, pv.pack.h, 0x32CB6DB6, 0x32CBBE72, 0x6DB6060F );
+  TEST_RR_OP( 11, pv.pack.h, 0xCB1900BC, 0xCB19A2A3, 0x00BCDD22 );
 
   #-------------------------------------------------------------
   # Source/Destination tests

--- a/software/riscv-tests/isa/snitch_isa.mk
+++ b/software/riscv-tests/isa/snitch_isa.mk
@@ -69,6 +69,7 @@ ifeq ($(xpulpimg),1)
 		pv_sdotusp \
 		pv_sdotsp \
 		pv_shuffle2 \
+		pv_pack \
 
 endif
 

--- a/software/riscv-tests/isa/snitch_isa.mk
+++ b/software/riscv-tests/isa/snitch_isa.mk
@@ -70,6 +70,7 @@ ifeq ($(xpulpimg),1)
 		pv_sdotsp \
 		pv_shuffle2 \
 		pv_pack \
+		pv_pack_h \
 
 endif
 

--- a/software/runtime/xpulp/builtins_v2.h
+++ b/software/runtime/xpulp/builtins_v2.h
@@ -16,7 +16,7 @@ typedef unsigned char v4u __attribute__((vector_size(4)));
 
 inline v2s __PACK2(const int32_t x, const int32_t y) {
   v2s output;
-  asm volatile("pv.pack.h %[z], %[x], %[y];"
+  asm volatile("pv.pack %[z], %[x], %[y];"
                : [z] "=r"(output)
                : [x] "r"(x), [y] "r"(y));
   return output;

--- a/toolchain/riscv-isa-sim/disasm/disasm.cc
+++ b/toolchain/riscv-isa-sim/disasm/disasm.cc
@@ -1514,6 +1514,7 @@ disassembler_t::disassembler_t(int xlen)
 
   DEFINE_RTYPE(pv_shuffle2_h);
   DEFINE_RTYPE(pv_shuffle2_b);
+  DEFINE_RTYPE(pv_pack);
   DEFINE_RTYPE(pv_pack_h);
 
   // provide a default disassembly for all instructions as a fallback

--- a/toolchain/riscv-isa-sim/riscv/insns/pv_pack.h
+++ b/toolchain/riscv-isa-sim/riscv/insns/pv_pack.h
@@ -1,0 +1,5 @@
+uint32_t ins_rd = RD;
+
+ins_rd = ((RS1_H(0) & 0x0000FFFF) << (xlen >> 1)) | ((RS2_H(0)) & 0x0000FFFF);
+
+WRITE_RD(sext_xlen(ins_rd));

--- a/toolchain/riscv-isa-sim/riscv/insns/pv_pack_h.h
+++ b/toolchain/riscv-isa-sim/riscv/insns/pv_pack_h.h
@@ -1,5 +1,5 @@
 uint32_t ins_rd = RD;
 
-ins_rd = ((RS1_H(0) & 0x0000FFFF) << (xlen >> 1)) | ((RS2_H(0)) & 0x0000FFFF);
+ins_rd = (RS1_H(1) & 0xFFFF0000) | ((RS2_H(1) & 0xFFFF0000) >> (xlen >> 1));
 
 WRITE_RD(sext_xlen(ins_rd));

--- a/toolchain/riscv-isa-sim/riscv/insns/pv_pack_h.h
+++ b/toolchain/riscv-isa-sim/riscv/insns/pv_pack_h.h
@@ -1,5 +1,5 @@
 uint32_t ins_rd = RD;
 
-ins_rd = ((RS1_H(0) & 0xFFFF) << (xlen >> 1)) | ((uint32_t)(RS1_H(0)) & 0x0000FFFF);
+ins_rd = ((RS1_H(0) & 0x0000FFFF) << (xlen >> 1)) | ((RS2_H(0)) & 0x0000FFFF);
 
 WRITE_RD(sext_xlen(ins_rd));

--- a/toolchain/riscv-isa-sim/riscv/riscv.mk.in
+++ b/toolchain/riscv-isa-sim/riscv/riscv.mk.in
@@ -932,6 +932,7 @@ riscv_insn_ext_xpulpimg = \
 	pv_sdotsp_sci_b \
 	pv_shuffle2_h \
 	pv_shuffle2_b \
+	pv_pack \
 	pv_pack_h \
 
 riscv_insn_ext_h = \


### PR DESCRIPTION
Add pv.pack instruction and fix pv.pack.h instruction.

### Fixed
- Add pv.pack support in Snitch, correct support for pv.pack.h
- Add pv.pack to Spike tests and add golden model to toolchain
- Correct occurrences of pv.pack.h with pv.pack
- Update submodules

## Checklist
- [ ] Automated tests pass
- [ ] Changelog updated
- [x] Code style guideline is observed