### PR TITLE
Tune axi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix the allocator initialization
 
 ### Changed
-- Increase the default AXI width
+- Increase the default AXI width to 512 for MemPool and TeraPool
 - Register all control signals at hierarchy boundaries
 - Upgrade to LLVM 14
 

--- a/config/config.mk
+++ b/config/config.mk
@@ -44,10 +44,10 @@ stack_size ?= 1024
 ##  AXI configuration  ##
 #########################
 # AXI bus data width (in bits)
-axi_data_width ?= 256
+axi_data_width ?= 512
 
 # Read-only cache line width in AXI interconnect (in bits)
-ro_line_width ?= 256
+ro_line_width ?= 512
 
 # Number of DMA backends in each group
 dmas_per_group ?= 4

--- a/config/minpool.mk
+++ b/config/minpool.mk
@@ -20,6 +20,15 @@ num_cores_per_tile ?= 4
 # L1 scratchpad banking factor
 banking_factor ?= 4
 
+#########################
+##  AXI configuration  ##
+#########################
+# AXI bus data width (in bits)
+axi_data_width ?= 256
+
+# Read-only cache line width in AXI interconnect (in bits)
+ro_line_width ?= 256
+
 # Number of DMA backends in each group
 dmas_per_group ?= 1
 

--- a/config/systolic.mk
+++ b/config/systolic.mk
@@ -19,7 +19,7 @@ num_cores_per_tile ?= 4
 banking_factor ?= 4
 
 # Radix for hierarchical AXI interconnect
-axi_hier_radix ?= 16
+axi_hier_radix ?= 20
 
 # Number of AXI masters per group
 axi_masters_per_group ?= 1

--- a/config/terapool.mk
+++ b/config/terapool.mk
@@ -21,7 +21,7 @@ num_cores_per_tile ?= 8
 banking_factor ?= 4
 
 # Radix for hierarchical AXI interconnect
-axi_hier_radix ?= 8
+axi_hier_radix ?= 10
 
 # Number of AXI masters per group
 axi_masters_per_group ?= 2

--- a/hardware/deps/snitch/src/snitch_read_only_cache/snitch_read_only_cache.sv
+++ b/hardware/deps/snitch/src/snitch_read_only_cache/snitch_read_only_cache.sv
@@ -278,7 +278,7 @@ module snitch_read_only_cache #(
   );
 
   // The lookup module contains the actual cache RAMs and performs lookups.
-  snitch_icache_lookup_parallel #(CFG) i_lookup (
+  snitch_icache_lookup_serial #(CFG) i_lookup (
     .clk_i,
     .rst_ni,
 

--- a/hardware/src/bootrom.sv
+++ b/hardware/src/bootrom.sv
@@ -8,7 +8,7 @@
 
 module bootrom #(
   /* Automatically generated. DO NOT CHANGE! */
-  parameter int unsigned DataWidth = 256,
+  parameter int unsigned DataWidth = 512,
   parameter int unsigned AddrWidth = 32
 ) (
   input  logic                 clk_i,
@@ -20,14 +20,14 @@ module bootrom #(
   localparam int AddrBits = RomSize > 1 ? $clog2(RomSize) : 1;
 
   const logic [RomSize-1:0][DataWidth-1:0] mem = {
-    256'h00000000_00000000_00000000_00000000_00050067_10500073_00050513_e0000517
+    512'h00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00050067_10500073_00050513_e0000517
   };
 
   logic [AddrBits-1:0] addr_q;
 
   always_ff @(posedge clk_i) begin
     if (req_i) begin
-      addr_q <= addr_i[AddrBits-1+5:5];
+      addr_q <= addr_i[AddrBits-1+6:6];
     end
   end
 

--- a/hardware/src/mempool_cluster.sv
+++ b/hardware/src/mempool_cluster.sv
@@ -105,7 +105,7 @@ module mempool_cluster
     .DmaRegionWidth (NumBanksPerGroup*4   ),
     .DmaRegionStart (TCDMBaseAddr         ),
     .DmaRegionEnd   (TCDMBaseAddr+TCDMSize),
-    .TransFifoDepth (8                    ),
+    .TransFifoDepth (16                   ),
     .burst_req_t    (dma_req_t            ),
     .meta_t         (dma_meta_t           )
   ) i_idma_distributed_midend (

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -458,7 +458,7 @@ module mempool_group
     .DmaRegionWidth (NumBanksPerGroup*4/NumDmasPerGroup),
     .DmaRegionStart (TCDMBaseAddr                      ),
     .DmaRegionEnd   (TCDMBaseAddr+TCDMSize             ),
-    .TransFifoDepth (4                                 ),
+    .TransFifoDepth (8                                 ),
     .burst_req_t    (dma_req_t                         ),
     .meta_t         (dma_meta_t                        )
   ) i_idma_distributed_midend (

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -377,6 +377,13 @@ module mempool_group
 
   axi_tile_req_t   [NumAXIMastersPerGroup-1:0] axi_mst_req;
   axi_tile_resp_t  [NumAXIMastersPerGroup-1:0] axi_mst_resp;
+  axi_tile_req_t  [NumTilesPerGroup+NumDmasPerGroup-1:0] axi_slv_req;
+  axi_tile_resp_t [NumTilesPerGroup+NumDmasPerGroup-1:0] axi_slv_resp;
+
+  for (genvar i = 0; i < NumDmasPerGroup; i++) begin : gen_axi_slv_vec
+    assign axi_slv_req[i*(NumTilesPerDma+1)+:NumTilesPerDma+1] = {axi_dma_req[i],axi_tile_req[i*NumTilesPerDma+:NumTilesPerDma]};
+    assign {axi_dma_resp[i],axi_tile_resp[i*NumTilesPerDma+:NumTilesPerDma]} = axi_slv_resp[i*(NumTilesPerDma+1)+:NumTilesPerDma+1];
+  end : gen_axi_slv_vec
 
   axi_hier_interco #(
     .NumSlvPorts    (NumTilesPerGroup+NumDmasPerGroup),
@@ -396,14 +403,14 @@ module mempool_group
     .mst_req_t      (axi_tile_req_t                  ),
     .mst_resp_t     (axi_tile_resp_t                 )
   ) i_axi_interco (
-    .clk_i           (clk_i                       ),
-    .rst_ni          (rst_ni                      ),
-    .test_i          (1'b0                        ),
-    .ro_cache_ctrl_i (ro_cache_ctrl_q             ),
-    .slv_req_i       ({axi_dma_req,axi_tile_req}  ),
-    .slv_resp_o      ({axi_dma_resp,axi_tile_resp}),
-    .mst_req_o       (axi_mst_req                 ),
-    .mst_resp_i      (axi_mst_resp                )
+    .clk_i           (clk_i          ),
+    .rst_ni          (rst_ni         ),
+    .test_i          (1'b0           ),
+    .ro_cache_ctrl_i (ro_cache_ctrl_q),
+    .slv_req_i       (axi_slv_req    ),
+    .slv_resp_o      (axi_slv_resp   ),
+    .mst_req_o       (axi_mst_req    ),
+    .mst_resp_i      (axi_mst_resp   )
   );
 
   for (genvar m = 0; m < NumAXIMastersPerGroup; m++) begin: gen_axi_group_cuts

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -517,7 +517,7 @@ module mempool_group
       .IdWidth         (AxiTileIdWidth ),
       .AxReqFifoDepth  (2              ),
       .TransFifoDepth  (1              ),
-      .BufferDepth     (3              ),
+      .BufferDepth     (4              ),
       .axi_req_t       (axi_tile_req_t ),
       .axi_res_t       (axi_tile_resp_t),
       .burst_req_t     (dma_req_t      ),


### PR DESCRIPTION
Tune the AXI interconnect and the DMA.

## Changelog

### Added

### Changed
- Change default AXI width to 512

### Fixed
- Fix DMA parameters to achieve full performance

(Reference to issues, labels, and related merge requests)

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
