### PR TITLE
Snitch WFI and Traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Increase the default AXI width to 512 for MemPool and TeraPool
 - Register all control signals at hierarchy boundaries
 - Upgrade to LLVM 14
+- Support multiple outstanding wake-up calls in Snitch
 
 ## 0.5.0 - 2022-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Register all control signals at hierarchy boundaries
 - Upgrade to LLVM 14
 - Support multiple outstanding wake-up calls in Snitch
+- Clean out tracing script and improve the traces' size and checks
 
 ## 0.5.0 - 2022-08-03
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -287,6 +287,11 @@ spyglass/tmp/files: $(bender)
 ################
 # Tracing      #
 ################
+
+# Give configuration in env
+trace_env += NUM_CORES=$(num_cores)
+trace_env += SEQ_MEM_SIZE=$(seq_mem_size)
+
 benchmark: log simcvcs
 	# Call `make` again to get variable extension with all traces
 	result_dir=$(result_dir) $(MAKE) trace
@@ -318,7 +323,7 @@ post_trace:
 $(buildpath)/%.trace: $(buildpath)/%.dasm
 	mkdir -p $(tracepath)
 	$(INSTALL_DIR)/riscv-isa-sim/bin/spike-dasm < $< > $(tracepath)/$*
-	$(python) $(ROOT_DIR)/scripts/gen_trace.py -p --csv $(traceresult) $(tracepath)/$* > $@
+	$(trace_env) $(python) $(ROOT_DIR)/scripts/gen_trace.py -p --csv $(traceresult) $(tracepath)/$* > $@
 
 tracevis:
 	$(MEMPOOL_DIR)/scripts/tracevis.py $(preload) $(buildpath)/*.trace -o $(buildpath)/tracevis.json

--- a/hardware/deps/snitch/src/snitch.sv
+++ b/hardware/deps/snitch/src/snitch.sv
@@ -1443,7 +1443,8 @@ module snitch
   always_ff @(posedge clk_i or posedge rst_i) begin
     // Display CSR write if the CSR does not exist
     if (!rst_i && csr_dump && inst_valid_o && inst_ready_i && !stall) begin
-      $display("[DUMP] %3d: 0x%3h = 0x%08h, %d", hart_id_i, inst_data_i[31:20], alu_result, alu_result);
+      $timeformat(-9, 0, " ns", 0);
+      $display("[DUMP] %t Core %3d: 0x%3h = 0x%08h, %d", $time, hart_id_i, inst_data_i[31:20], alu_result, alu_result);
     end
   end
   // pragma translate_on

--- a/hardware/deps/snitch/src/snitch.sv
+++ b/hardware/deps/snitch/src/snitch.sv
@@ -91,6 +91,7 @@ module snitch
   localparam int RegWidth = RVE ? 4 : 5;
   localparam int RegNrReadPorts = snitch_pkg::XPULPIMG ? 3 : 2;
   localparam logic [RegWidth-1:0] SP = 2;
+  localparam int OutstandingWfi = 8;
 
   logic illegal_inst;
   logic zero_lsb;
@@ -98,7 +99,7 @@ module snitch
   // Instruction fetch
   logic [31:0] pc_d, pc_q;
   logic wfi_d, wfi_q;
-  logic wake_up_d, wake_up_q;
+  logic [$clog2(OutstandingWfi)-1:0] wake_up_d, wake_up_q;
   logic [31:0] consec_pc;
   // Immediates
   logic [31:0] iimm, uimm, jimm, bimm, simm, pbimm;
@@ -346,7 +347,7 @@ module snitch
     // Wake up if a wake-up is incoming or pending
     wfi_d = (wake_up_q || wake_up_sync_i) ? 1'b0 : wfi_q;
     // Only store a pending wake-up if we are not asleep
-    wake_up_d = (wake_up_sync_i && !wfi_q) ? 1'b1 : wake_up_q;
+    wake_up_d = (wake_up_sync_i && !wfi_q) ? wake_up_q + 1 : wake_up_q;
 
     unique casez (inst_data_i)
       riscv_instr::ADD: begin
@@ -643,7 +644,14 @@ module snitch
           if (wake_up_q || wake_up_sync_i) begin
             // Do not sleep if a wake-up is pending
             wfi_d = 1'b0;
-            wake_up_d = 1'b0;
+            if (wake_up_q) begin
+              // Decrement outstanding wake_up pulses
+              wake_up_d = wake_up_q - 1;
+            end
+            if (wake_up_sync_i) begin
+              // Keep counter constant due to simultaneous pulse
+              wake_up_d = wake_up_q;
+            end
           end
         end
       end
@@ -1361,7 +1369,7 @@ module snitch
     if (!rst_i && illegal_inst && inst_valid_o && inst_ready_i) begin
       $display("[Illegal Instruction Core %0d] PC: %h Data: %h", hart_id_i, inst_addr_o, inst_data_i);
     end
-    if (!rst_i && wake_up_sync_i && wake_up_q) begin
+    if (!rst_i && wake_up_sync_i && &wake_up_q) begin
       $display("[Missed wake-up Core %0d] Cycle: %d, Time: %t", hart_id_i, cycle_q, $time);
     end
   end

--- a/hardware/scripts/gen_trace.py
+++ b/hardware/scripts/gen_trace.py
@@ -11,11 +11,6 @@
 # Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
 #         Samuel Riedel <sriedel@iis.ee.ethz.ch>
 
-# TODO: OPER_TYPES and FPU_OPER_TYPES could break: optimization might alter
-# enum mapping
-# TODO: We annotate all FP16 LSU values as IEEE, not FP16ALT... can we do
-# better?
-
 import sys
 import os
 import re
@@ -56,7 +51,6 @@ PERF_EVAL_KEYS_OMIT = (
     'snitch_store_region',
     'snitch_store_tile')
 
-
 # -------------------- Architectural constants and enums  --------------------
 
 REG_ABI_NAMES_I = (
@@ -68,28 +62,12 @@ REG_ABI_NAMES_I = (
     *('t{}'.format(i) for i in range(3, 7))
 )
 
-REG_ABI_NAMES_F = (
-    *('ft{}'.format(i) for i in range(0, 8)),
-    'fs0', 'fs1',
-    'fa0', 'fa1',
-    *('fa{}'.format(i) for i in range(2, 8)),
-    *('fs{}'.format(i) for i in range(2, 12)),
-    *('ft{}'.format(i) for i in range(8, 12))
-)
-
-TRACE_SRCES = {'snitch': 0, 'fpu': 1, 'sequencer': 2}
-
 LS_SIZES = ('Byte', 'Half', 'Word', 'Doub')
 
 OPER_TYPES = {'gpr': 1, 'csr': 8}
 
-FPU_OPER_TYPES = ('NONE', 'acc', 'rs1', 'rs2', 'rs3', 'rs1', 'rd')
-
-FLOAT_FMTS = ((8, 23), (11, 52), (5, 10), (5, 2), (8, 7))
-
-LS_TO_FLOAT = (3, 2, 0, 1)
-
-CSR_NAMES = {0xb00: 'mcycle', 0xf14: 'mhartid'}
+CSR_NAMES = {0xb00: 'mcycle', 0xb02: 'minstret',
+             0xf14: 'mhartid', 0x7d0: 'trace', 0x7d1: 'stacklimit'}
 
 MEM_REGIONS = {'Other': 0, 'Sequential': 1, 'Interleaved': 2}
 
@@ -98,161 +76,8 @@ RAW_TYPES = ['lsu', 'acc']
 # ----------------- Architecture Info  -----------------
 NUM_CORES = int(os.environ.get('num_cores', 256))
 NUM_TILES = NUM_CORES / 4
-SEQ_MEM_SIZE = 4 * 1024
+SEQ_MEM_SIZE = 4 * int(os.environ.get('seq_mem_size', 1024))
 TCDM_SIZE = 16 * 1024 * NUM_TILES
-
-# -------------------- FPU helpers  --------------------
-
-
-def flt_oper(extras: dict, port: int) -> (str, str):
-    op_sel = extras['op_sel_{}'.format(port)]
-    oper_type = FPU_OPER_TYPES[op_sel]
-    if oper_type == 'acc':
-        return 'ac{}'.format(
-            port + 1), int_lit(
-            extras['acc_qdata_{}'.format(port)], extras['int_fmt'])
-    elif oper_type == 'NONE':
-        return oper_type, None
-    else:
-        fmt = LS_TO_FLOAT[extras['ls_size']
-                          ] if extras['is_store'] else extras['src_fmt']
-        return REG_ABI_NAMES_F[extras[oper_type]], flt_lit(
-            extras['op_{}'.format(port)], fmt)
-
-
-def flt_decode(val: int, fmt: int) -> float:
-    # get format and bit vector
-    w_exp, w_mnt = FLOAT_FMTS[fmt]
-    width = 1 + w_exp + w_mnt
-    bitstr = '{:064b}'.format(val)[-width:]
-    # print(bitstr)
-    # Read bit vector slices
-    sgn = -1.0 if bitstr[0] == '1' else 1.0
-    mnt = int(bitstr[w_exp + 1:], 2)
-    exp_unb = int(bitstr[1:w_exp + 1], 2)
-    # derive base and exponent
-    bse = int('1' + bitstr[w_exp + 1:], 2) / (2 ** w_mnt)
-    exp_bias = -(2 ** (w_exp - 1) - 1)
-    exp = exp_unb + exp_bias
-    # case analysis
-    if exp_unb == 2 ** w_exp - 1:
-        return sgn * float('inf' if mnt == 0 else 'nan')
-    elif exp_unb == 0 and mnt == 0:
-        return sgn * 0.0
-    elif exp_unb == 0:
-        return float(sgn * mnt / (2 ** w_mnt) * (2 ** (exp_bias + 1)))
-    else:
-        return float(sgn * bse * (2 ** exp))
-
-
-def flt_fmt(flt: float, width: int = 7) -> str:
-    # If default literal shorter: use it
-    default_str = str(flt)
-    if len(default_str) - 1 <= width:
-        return default_str
-    # Else: fix significant digits, using exponential if needed
-    exp, _ = math.frexp(flt)
-    fmt = '{:1.' + str(width - 3) + 'e}'
-    if not math.isnan(exp) and -1 < exp <= width:
-        exp = int(exp)
-        fmt = '{:' + str(exp) + '.' + str(width - exp) + 'f}'
-    return fmt.format(flt)
-
-
-# -------------------- Literal formatting  --------------------
-
-def int_lit(num: int, size: int = 2, force_hex: bool = False) -> str:
-    if type(num) is str:
-        sys.stderr.write('WARNING: Trace contains Xs!\n')
-        return num
-    width = (8 * int(2 ** size))
-    size_mask = (0x1 << width) - 1
-    num = num & size_mask  # num is unsigned
-    num_signed = c_int32(c_uint32(num).value).value
-    if force_hex or abs(num_signed) > MAX_SIGNED_INT_LIT:
-        return '0x{0:0{1}x}'.format(num, width // 4)
-    else:
-        return str(num_signed)
-
-
-def flt_lit(num: int, fmt: int, width: int = 7) -> str:
-    return flt_fmt(flt_decode(num, fmt), width)
-
-
-# -------------------- FPU Sequencer --------------------
-
-def dasm_seq(extras: dict,) -> str:
-    return '{:<8}'.format('frep') + ', '.join(
-        [str(extras['max_rpt'] + 1), str(extras['max_inst'] + 1)] +
-        ([bin(extras['stg_mask']), str(extras['stg_max'] + 1)]
-         if extras['stg_mask'] else []))
-
-
-def emul_seq(fseq_info: dict,
-             permissive: bool = False) -> (str,
-                                           int,
-                                           str,
-                                           tuple):
-    fseq_annot = None
-    # We are only called on FPSS issues, not on FSEQ issues -> we must consume
-    # FReps in same call
-    cfg = fseq_info['curr_cfg']
-    if cfg is None:
-        is_frep = fseq_info['fpss_pcs'][-1][2] if len(
-            fseq_info['fpss_pcs']) else False
-        # Is an FRep incoming?
-        if is_frep:
-            fseq_info['fpss_pcs'].pop()
-            cfg = fseq_info['cfg_buf'].pop()
-            cfg['inst_iter'] = 0
-            cfg['fpss_buf'] = deque()
-            cfg['outer_buf'] = deque()
-            fseq_info['curr_cfg'] = cfg
-    # Are we working on an FRep ...
-    if cfg is not None:
-        # If we are still filling our loop buffer: add to it and replicate
-        if cfg['inst_iter'] <= cfg['max_inst']:
-            pc_str, curr_sec, is_frep = fseq_info['fpss_pcs'].pop()
-            if is_frep:
-                msg_type = 'WARNING' if permissive else 'FATAL'
-                sys.stderr.write(
-                    '{}: FRep at {} contains another nested FRep'.format(
-                        msg_type, cfg['fseq_pc']))
-                if not permissive:
-                    sys.exit(1)
-            # Outer loops: first consume loop body, then replicate buffer
-            if cfg['is_outer']:
-                buf_entry = (pc_str, curr_sec, (0, cfg['inst_iter']))
-                cfg['fpss_buf'].appendleft(buf_entry)
-                cfg['outer_buf'].appendleft(buf_entry)
-                # Once all loop instructions received: replicate buffer in
-                # outer-loop order
-                if cfg['inst_iter'] == cfg['max_inst']:
-                    for curr_rep in range(1, cfg['max_rpt'] + 1):
-                        ob_rev = reversed(cfg['outer_buf'])
-                        for inst_idx, inst in enumerate(ob_rev):
-                            pc_str, curr_sec, _ = inst
-                            fseq_annot = (curr_rep, inst_idx)
-                            cfg['fpss_buf'].appendleft(
-                                (pc_str, curr_sec, fseq_annot))
-            # Inner loops: replicate instructions during loop body consumption
-            else:
-                for curr_rep in range(0, cfg['max_rpt'] + 1):
-                    fseq_annot = (curr_rep, cfg['inst_iter'])
-                    cfg['fpss_buf'].appendleft((pc_str, curr_sec, fseq_annot))
-            # Iterate loop body instruction consumed
-            cfg['inst_iter'] += 1
-        # Pull our instruction from the loop buffer
-        pc_str, curr_sec, fseq_annot = cfg['fpss_buf'].pop()
-        # If we reached last iteration: terminate this FRep
-        if (fseq_annot[0] == cfg['max_rpt']
-                and fseq_annot[1] == cfg['max_inst']):
-            fseq_info['curr_cfg'] = None
-    # ... or is this a regular pass-through?
-    else:
-        pc_str, curr_sec, _ = fseq_info['fpss_pcs'].pop()
-    fseq_pc_str = None if cfg is None else cfg['fseq_pc']
-    return pc_str, curr_sec, fseq_pc_str, fseq_annot
 
 
 def addr_to_meta(address):
@@ -268,6 +93,36 @@ def addr_to_meta(address):
         tile = address // 64
         tile = tile % NUM_TILES
     return region, tile
+
+
+def flt_fmt(flt: float, width: int = 7) -> str:
+    # If default literal shorter: use it
+    default_str = str(flt)
+    if len(default_str) - 1 <= width:
+        return default_str
+    # Else: fix significant digits, using exponential if needed
+    exp, _ = math.frexp(flt)
+    fmt = '{:1.' + str(width - 3) + 'e}'
+    if not math.isnan(exp) and -1 < exp <= width:
+        exp = int(exp)
+        fmt = '{:' + str(exp) + '.' + str(width - exp) + 'f}'
+    return fmt.format(flt)
+
+# -------------------- Literal formatting  --------------------
+
+
+def int_lit(num: int, size: int = 2, force_hex: bool = False) -> str:
+    if type(num) is str:
+        sys.stderr.write('WARNING: Trace contains Xs!\n')
+        return num
+    width = (8 * int(2 ** size))
+    size_mask = (0x1 << width) - 1
+    num = num & size_mask  # num is unsigned
+    num_signed = c_int32(c_uint32(num).value).value
+    if force_hex or abs(num_signed) > MAX_SIGNED_INT_LIT:
+        return '0x{0:0{1}x}'.format(num, width // 4)
+    else:
+        return str(num_signed)
 
 # -------------------- Annotation --------------------
 
@@ -293,7 +148,6 @@ def annotate_snitch(
     prev_wfi_time: int,
     retired_reg: dict,
     perf_metrics: list,
-    annot_fseq_offl: bool = False,
     force_hex_addr: bool = True,
     permissive: bool = False
 ) -> (str, dict):
@@ -301,15 +155,11 @@ def annotate_snitch(
     ret = []
     # Remember if we had a potential RAW stall
     raw_stall = {k: 0 for k in RAW_TYPES}
-    # If Sequencer offload: annotate if desired
-    if annot_fseq_offl and extras['fpu_offload']:
-        target_name = 'FSEQ' if extras['is_seq_insn'] else 'FPSS'
-        ret.append('{} <~~ 0x{:08x}'.format(target_name, pc))
     # Add start time if this is this section's first instruction
     if perf_metrics[-1]['start'] is None:
         perf_metrics[-1]['start'] = cycle - extras['stall_tot']
     # Regular linear datapath operation
-    if not (extras['stall'] or extras['fpu_offload']):
+    if not extras['stall']:
         # Check whether a register that is accessed was retired earlier
         for k in RAW_TYPES:
             for reg in ['rs1', 'rs2', 'rd']:
@@ -363,7 +213,7 @@ def annotate_snitch(
                 REG_ABI_NAMES_I[extras['rd']], int_lit(extras['writeback'])))
     # Retired loads and accelerator (includes FPU) data: can come back on
     # stall and during other ops
-    if extras['retire_load'] and extras['lsu_rd'] != 0:
+    if extras['retire_load']:
         try:
             start_time, address = gpr_wb_info[extras['lsu_rd']].pop()
             region, tile = addr_to_meta(address)
@@ -432,93 +282,12 @@ def annotate_snitch(
     return ', '.join(ret), retired_reg
 
 
-def annotate_fpu(
-    extras: dict,
-    cycle: int,
-    fpr_wb_info: dict,
-    perf_metrics: list,
-    # Everything FPU does may have been issued in a previous section
-    curr_sec: int = -1,
-    force_hex_addr: bool = True,
-    permissive: bool = False
-) -> str:
-    ret = []
-    # On issuing of instruction
-    if extras['acc_q_hs']:
-        # If computation initiated: remember FPU destination format
-        if extras['use_fpu'] and not extras['fpu_in_acc']:
-            fpr_wb_info[extras['fpu_in_rd']].appendleft(
-                (extras['dst_fmt'], cycle))
-        # Operands: omit on store
-        if not extras['is_store']:
-            for i_op in range(3):
-                oper_name, val = flt_oper(extras, i_op)
-                if oper_name != 'NONE':
-                    ret.append('{:<4} = {}'.format(oper_name, val))
-        # Load / Store requests
-        if extras['lsu_q_hs']:
-            s = extras['ls_size']
-            if extras['is_load']:
-                perf_metrics[curr_sec]['fpss_loads'] += 1
-                # Load initiated: remember LSU destination format
-                fpr_wb_info[extras['rd']].appendleft((LS_TO_FLOAT[s], cycle))
-                ret.append('{:<4} <~~ {}[{}]'
-                           .format(REG_ABI_NAMES_F[extras['rd']],
-                                   LS_SIZES[s],
-                                   int_lit(extras['lsu_qaddr'],
-                                           force_hex=force_hex_addr)))
-            if extras['is_store']:
-                perf_metrics[curr_sec]['fpss_stores'] += 1
-                _, val = flt_oper(extras, 1)
-                ret.append(
-                    '{} ~~> {}[{}]'.format(
-                        val,
-                        LS_SIZES[s],
-                        int_lit(
-                            extras['lsu_qaddr'],
-                            force_hex=force_hex_addr)))
-    # On FLOP completion
-    if extras['fpu_out_hs']:
-        perf_metrics[-1]['fpss_fpu_issues'] += 1
-    # Register writeback
-    if extras['fpr_we']:
-        writer = 'acc' if extras['acc_q_hs'] and extras['acc_wb_ready'] else (
-            'fpu' if extras['fpu_out_hs'] and not extras['fpu_out_acc']
-            else 'lsu')
-        fmt = 0  # accelerator bus format is 0 for regular float32
-        if writer == 'fpu' or writer == 'lsu':
-            try:
-                fmt, start_time = fpr_wb_info[extras['fpr_waddr']].pop()
-                if writer == 'lsu':
-                    perf_metrics[curr_sec]['fpss_load_latency'] += (
-                        cycle - start_time)
-                else:
-                    perf_metrics[curr_sec]['fpss_fpu_latency'] += (
-                        cycle - start_time)
-            except IndexError:
-                msg_type = 'WARNING' if permissive else 'FATAL'
-                sys.stderr.write(('{}: In cycle {}, {} attempts writeback to '
-                                  '{}, but none in flight.\n').format(
-                    msg_type, cycle, writer.upper(),
-                    REG_ABI_NAMES_F[extras['fpr_waddr']]))
-                if not permissive:
-                    sys.exit(1)
-        ret.append('(f:{}) {:<4} <-- {}'
-                   .format(writer, REG_ABI_NAMES_F[extras['fpr_waddr']],
-                           flt_lit(extras['fpr_wdata'], fmt)))
-    return ', '.join(ret)
-
-
-# noinspection PyTypeChecker
 def annotate_insn(
     line: str,
     # One deque (FIFO) per GPR storing start cycles for each GPR WB
     gpr_wb_info: dict,
-    # One deque (FIFO) per FPR storing start cycles and formats for each FPR WB
-    fpr_wb_info: dict,
-    # Info on the sequencer to properly map tunneled instruction PCs
-    fseq_info: dict,
-    perf_metrics: list,  # A list performance metric dicts
+    # A list performance metric dicts
+    perf_metrics: list,
     # Show sim time and cycle again if same as previous line?
     dupl_time_info: bool = True,
     # Previous timestamp (keeps this method stateless)
@@ -528,7 +297,6 @@ def annotate_insn(
     # Previous retired instructions (keeps this method stateless)
     retired_reg: dict = {k: 0 for k in RAW_TYPES},
     # Annotate whenever core offloads to CPU on own line
-    annot_fseq_offl: bool = False,
     force_hex_addr: bool = True,
     permissive: bool = True
 ) -> (str, tuple, int, dict, bool):
@@ -545,63 +313,15 @@ def annotate_insn(
     if extras_str:
         extras = read_annotations(extras_str)
         # Annotate snitch
-        if extras['source'] == TRACE_SRCES['snitch']:
-            (annot, retired_reg) = annotate_snitch(
-                extras, time_info[1], last_time_info[1],
-                int(pc_str, 16), gpr_wb_info, prev_wfi_time, retired_reg,
-                perf_metrics, annot_fseq_offl, force_hex_addr,
-                permissive)
-            if extras['fpu_offload']:
-                perf_metrics[-1]['snitch_fseq_offloads'] += 1
-                fseq_info['fpss_pcs'].appendleft(
-                    (pc_str, len(perf_metrics) - 1, extras['is_seq_insn']))
-                if extras['is_seq_insn']:
-                    fseq_info['fseq_pcs'].appendleft(pc_str)
-            if extras['stall'] or extras['fpu_offload']:
-                insn, pc_str = ('', '')
-            else:
-                perf_metrics[-1]['snitch_issues'] += 1
-        # Annotate sequencer
-        elif extras['source'] == TRACE_SRCES['sequencer']:
-            if extras['cbuf_push']:
-                fseq_info['cfg_buf'].appendleft(extras)
-                frep_pc_str = fseq_info['fseq_pcs'].pop()
-                insn, pc_str = (dasm_seq(extras), frep_pc_str)
-                extras['fseq_pc'] = frep_pc_str
-                annot = ', '.join(['outer' if extras['is_outer'] else 'inner',
-                                   '{} issues'.format(
-                    (extras['max_inst'] + 1) * (extras['max_rpt'] + 1))])
-            else:
-                insn, pc_str, annot = ('', '', '')
-        # Annotate FPSS
-        elif extras['source'] == TRACE_SRCES['fpu']:
-            annot_list = []
-            if not extras['acc_q_hs']:
-                insn, pc_str = ('', '')
-            else:
-                pc_str, curr_sec, fseq_pc_str, fseq_annot = emul_seq(
-                    fseq_info, permissive)
-                fseq_info['curr_sec'] = curr_sec
-                # Record cycle in case this was last insn in section
-                perf_metrics[curr_sec]['end_fpss'] = time_info[1]
-                perf_metrics[curr_sec]['fpss_issues'] += 1
-                if fseq_annot is not None:
-                    annot_list.append('[{} {}:{}]'.format(
-                        fseq_pc_str[-4:], *fseq_annot))
-            annot_list.append(
-                annotate_fpu(
-                    extras,
-                    time_info[1],
-                    fpr_wb_info,
-                    perf_metrics,
-                    fseq_info['curr_sec'],
-                    force_hex_addr,
-                    permissive))
-            annot = ', '.join(annot_list)
+        (annot, retired_reg) = annotate_snitch(
+            extras, time_info[1], last_time_info[1],
+            int(pc_str, 16), gpr_wb_info, prev_wfi_time, retired_reg,
+            perf_metrics, force_hex_addr,
+            permissive)
+        if extras['stall']:
+            insn, pc_str = ('', '')
         else:
-            raise ValueError(
-                'Unknown trace source: {}'.format(
-                    extras['source']))
+            perf_metrics[-1]['snitch_issues'] += 1
         # omit empty trace lines (due to double stalls, performance measures)
         empty = not (insn or annot)
         if empty:
@@ -812,11 +532,6 @@ def main():
         help='A matching ASCII signal dump',
     )
     parser.add_argument(
-        '-o',
-        '--offl',
-        action='store_true',
-        help='Annotate FPSS and sequencer offloads when they happen in core')
-    parser.add_argument(
         '-s',
         '--saddr',
         action='store_true',
@@ -854,14 +569,6 @@ def main():
     prev_wfi_time = 0
     retired_reg = {k: -1 for k in RAW_TYPES}
     gpr_wb_info = defaultdict(deque)
-    fpr_wb_info = defaultdict(deque)
-    fseq_info = {
-        'curr_sec': 0,
-        'fpss_pcs': deque(),
-        'fseq_pcs': deque(),
-        'cfg_buf': deque(),
-        'curr_cfg': None
-    }
     perf_metrics = [defaultdict(int)]
     perf_metrics[0]['start'] = None
     section = 0
@@ -869,10 +576,9 @@ def main():
     for line in line_iter:
         if line:
             ann_insn, time_info, prev_wfi_time, retired_reg, empty = \
-                annotate_insn(line, gpr_wb_info, fpr_wb_info, fseq_info,
-                              perf_metrics, False, time_info, prev_wfi_time,
-                              retired_reg, args.offl, not args.saddr,
-                              args.permissive)
+                annotate_insn(line, gpr_wb_info, perf_metrics, False,
+                              time_info, prev_wfi_time, retired_reg,
+                              not args.saddr, args.permissive)
             if perf_metrics[0]['start'] is None:
                 perf_metrics[0]['start'] = time_info[1]
             # Start a new benchmark section after 'csrw trace' instruction
@@ -915,19 +621,8 @@ def main():
             csv_file = os.path.join(path, csv_file)
         perf_metrics_to_csv(perf_metrics, csv_file)
     # Check for any loose ends and warn before exiting
-    seq_isns = len(fseq_info['fseq_pcs']) + len(fseq_info['cfg_buf'])
-    unseq_left = len(fseq_info['fpss_pcs']) - len(fseq_info['fseq_pcs'])
-    fseq_cfg = fseq_info['curr_cfg']
     warn_trip = False
-    for fpr, que in fpr_wb_info.items():
-        if len(que) != 0:
-            warn_trip = True
-            sys.stderr.write(
-                EXTRA_WB_WARN.format(
-                    len(que),
-                    REG_ABI_NAMES_F[fpr]) +
-                '\n')
-    for gpr, que in fpr_wb_info.items():
+    for gpr, que in gpr_wb_info.items():
         if len(que) != 0:
             warn_trip = True
             sys.stderr.write(
@@ -935,22 +630,6 @@ def main():
                     len(que),
                     REG_ABI_NAMES_I[gpr]) +
                 '\n')
-    if seq_isns:
-        warn_trip = True
-        sys.stderr.write(
-            'WARNING: {} Sequencer instructions were not issued.\n'
-            .format(seq_isns))
-    if unseq_left:
-        warn_trip = True
-        sys.stderr.write(
-            'WARNING: {} unsequenced FPSS instructions were not issued.\n'
-            .format(unseq_left))
-    if fseq_cfg is not None:
-        warn_trip = True
-        pc_str = fseq_cfg['fseq_pc']
-        sys.stderr.write(
-            ('WARNING: Not all FPSS instructions from sequence {} were '
-             ' issued.\n').format(pc_str))
     if warn_trip:
         sys.stderr.write(GENERAL_WARN)
     return 0

--- a/hardware/src/mempool_cc.sv
+++ b/hardware/src/mempool_cc.sv
@@ -234,7 +234,7 @@ module mempool_cc
           extras_str = "{";
           // State
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "source",      SrcSnitch);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "stall",       i_snitch.stall);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "stall",       i_snitch.stall);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "stall_tot",   stall);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "stall_ins",   stall_ins);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "stall_raw",   stall_raw);
@@ -244,37 +244,34 @@ module mempool_cc
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "rs1",         i_snitch.rs1);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "rs2",         i_snitch.rs2);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "rd",          i_snitch.rd);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "is_load",     i_snitch.is_load);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "is_store",    i_snitch.is_store);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "is_branch",   i_snitch.is_branch);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "is_load",     i_snitch.is_load);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "is_store",    i_snitch.is_store);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "is_branch",   i_snitch.is_branch);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "pc_d",        i_snitch.pc_d);
           // Operands
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "opa",         i_snitch.opa);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "opb",         i_snitch.opb);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "opa_select",  i_snitch.opa_select);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "opb_select",  i_snitch.opb_select);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "opc_select",  i_snitch.opc_select);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "write_rd",    i_snitch.write_rd);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "csr_addr",    i_snitch.inst_data_i[31:20]);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "opa_select",  i_snitch.opa_select);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "opb_select",  i_snitch.opb_select);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "opc_select",  i_snitch.opc_select);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "write_rd",    i_snitch.write_rd);
+          extras_str = $sformatf("%s'%s': 0x%3x, ", extras_str, "csr_addr",    i_snitch.inst_data_i[31:20]);
           // Pipeline writeback
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "writeback",   i_snitch.alu_writeback);
           // Load/Store
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "gpr_rdata_1", i_snitch.gpr_rdata[1]);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "gpr_rdata_2", i_snitch.gpr_rdata[2]);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "ls_size",     i_snitch.ls_size);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "ls_size",     i_snitch.ls_size);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "ld_result_32",i_snitch.ld_result[31:0]);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "lsu_rd",      i_snitch.lsu_rd);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "retire_load", i_snitch.retire_load);
+          extras_str = $sformatf("%s'%s': 0x%2x, ", extras_str, "lsu_rd",      i_snitch.lsu_rd);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "retire_load", i_snitch.retire_load);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "alu_result",  i_snitch.alu_result);
           // Atomics
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "ls_amo",      i_snitch.ls_amo);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "ls_amo",      i_snitch.ls_amo);
           // Accumulator
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "retire_acc",  i_snitch.retire_acc);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "acc_pid",     i_snitch.acc_pid_i);
+          extras_str = $sformatf("%s'%s': 0x%1x, ", extras_str, "retire_acc",  i_snitch.retire_acc);
+          extras_str = $sformatf("%s'%s': 0x%2x, ", extras_str, "acc_pid",     i_snitch.acc_pid_i);
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "acc_pdata_32",i_snitch.acc_pdata_i[31:0]);
-          // FPU offload
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "fpu_offload", 1'b0);
-          extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "is_seq_insn", 1'b0);
           extras_str = $sformatf("%s}", extras_str);
 
           $timeformat(-9, 0, "", 10);

--- a/hardware/src/mempool_cc.sv
+++ b/hardware/src/mempool_cc.sv
@@ -277,6 +277,7 @@ module mempool_cc
           extras_str = $sformatf("%s'%s': 0x%8x, ", extras_str, "is_seq_insn", 1'b0);
           extras_str = $sformatf("%s}", extras_str);
 
+          $timeformat(-9, 0, "", 10);
           $sformat(trace_entry, "%t %8d 0x%h DASM(%h) #; %s\n",
               $time, cycle, i_snitch.pc_q, i_snitch.inst_data_i, extras_str);
           $fwrite(f, trace_entry);

--- a/hardware/tb/verilator/verilator.flags
+++ b/hardware/tb/verilator/verilator.flags
@@ -45,3 +45,6 @@
 
 // Flush streams after each $display. The timing impact is usually nonmeasurable
 --autoflush
+
+// Set timescale to get consistent results with Modelsim/VCS
+--timescale 1ns/1ns


### PR DESCRIPTION
Add the capability to support multiple outstanding wake-up triggers in Snitch and improve its tracing. Specifically, reduce the trace's size, parsing speed, and sanity checks. This PR also ensures that the traces have the same time format in all simulation platforms and that the time is printed in debug statements, facilitating debugging.

## Changelog

### Changed
- Support multiple outstanding wake-up calls in Snitch
- Clean out tracing script and improve the traces' size and checks

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed