### PR TITLE
[tb] Add support to trace retired TCDM operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a DMA
 - Add support to hardrware-accelerated queues for CGRA (RV32A extension)
 - Add systolic implementation of matmul and 2d convolution exploiting hardware-accelerated queues
+- Add ability to Trace the operations retired by the TCDM adapters  
 
 ### Fixed
 - Measure the `wfi` stalls and stalls caused by `opc` properly

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,4 +11,5 @@ Thanks to all.
 * Marc Gantenbein
 * Marco Bertuletti
 * Sergio Mazzola
+* Vaibhav Krishna
 * Yichao Zhang

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -47,6 +47,7 @@ verilator_top   ?= mempool_tb_verilator
 python          ?= python3
 # Enable tracing
 snitch_trace    ?= 0
+bank_trace		  ?= 0
 
 # Check if the specified QuestaSim version exists
 ifeq (, $(shell which $(questa_cmd)))
@@ -90,12 +91,16 @@ vlog_args += -work $(library)
 vlog_defs += -DNUM_CORES=$(num_cores) -DNUM_CORES_PER_TILE=$(num_cores_per_tile) -DNUM_GROUPS=$(num_groups) -DBANKING_FACTOR=$(banking_factor)
 vlog_defs += -DL2_BASE=$(l2_base) -DL2_SIZE=$(l2_size) -DL2_BANKS=$(l2_banks)
 vlog_defs += -DBOOT_ADDR=$(boot_addr) -DXPULPIMG=$(xpulpimg)
-vlog_defs += -DSNITCH_TRACE=$(snitch_trace)
+vlog_defs += -DSNITCH_TRACE=$(snitch_trace) -DBANK_TRACE=$(bank_trace)
 vlog_defs += -DAXI_DATA_WIDTH=$(axi_data_width)
 vlog_defs += -DRO_LINE_WIDTH=$(ro_line_width)
 vlog_defs += -DDMAS_PER_GROUP=$(dmas_per_group)
 vlog_defs += -DAXI_HIER_RADIX=$(axi_hier_radix) -DAXI_MASTERS_PER_GROUP=$(axi_masters_per_group)
 vlog_defs += -DSEQ_MEM_SIZE=$(seq_mem_size) -DXQUEUE=$(xqueue) -DXQUEUE_SIZE=$(xqueue_size)
+
+ifeq ($(xqueue),1)
+	vlog_defs+= -DXQUEUE_TCDM_ADAPTER 
+endif
 
 # Traffic generation enabled
 ifdef tg


### PR DESCRIPTION
Summarize the changes concisely

## Changelog

### Added
- Added the ability to Trace the operations retired by the TCDM adapters. When XQueue = 1, Queue operations, AMO and Load/Store operations are traced and when Xqueue = 0, only Load/Store operations are traced.

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
