### PR TITLE
Specify CI's Ubuntu and Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   #  Toolchains  #
   ################
   tc-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Recover the submodule commit hash
@@ -41,7 +41,7 @@ jobs:
         path: riscv-gnu-toolchain.tzst
 
   tc-llvm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Recover the submodule commit hash
@@ -70,7 +70,7 @@ jobs:
         path: llvm-project.tzst
 
   tc-halide:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: tc-llvm
     steps:
     - uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
   #  Tools  #
   ###########
   riscv-isa-sim:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Cache riscv-isa-sim
@@ -137,7 +137,7 @@ jobs:
         path: riscv-isa-sim.tzst
 
   verilator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Recover the submodule commit hash
@@ -171,7 +171,7 @@ jobs:
   #  Build Hardware  #
   ####################
   verilator-model:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     needs: verilator
     strategy:
@@ -216,7 +216,7 @@ jobs:
   #  Regenerate files  #
   ######################
   check-bootrom:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: tc-gcc
     steps:
     - uses: actions/checkout@v3
@@ -235,7 +235,7 @@ jobs:
         git diff --exit-code
 
   check-opcodes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Regenerate opcodes
@@ -247,7 +247,7 @@ jobs:
   #  Build Software  #
   ####################
   build-apps-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: tc-gcc
     strategy:
       matrix:
@@ -277,7 +277,7 @@ jobs:
         path: apps-gcc.tzst
 
   build-apps-llvm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [tc-gcc, tc-llvm]
     strategy:
       matrix:
@@ -313,7 +313,7 @@ jobs:
         path: apps-llvm.tzst
 
   build-apps-halide:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [tc-gcc, tc-llvm, tc-halide]
     strategy:
       matrix:
@@ -353,7 +353,7 @@ jobs:
         path: apps-halide.tzst
 
   build-apps-omp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: tc-gcc
     strategy:
       matrix:
@@ -384,7 +384,7 @@ jobs:
   #  Run Software  #
   ##################
   run-apps-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     needs: [build-apps-gcc, riscv-isa-sim, verilator-model]
     strategy:
@@ -422,7 +422,7 @@ jobs:
         make trace
 
   run-apps-llvm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     needs: [build-apps-llvm, riscv-isa-sim, verilator-model]
     strategy:
@@ -460,7 +460,7 @@ jobs:
         make trace
 
   run-apps-halide:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     needs: [build-apps-halide, riscv-isa-sim, verilator-model]
     strategy:
@@ -498,7 +498,7 @@ jobs:
         make trace
 
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     needs: [tc-gcc, riscv-isa-sim, verilator-model]
     steps:
@@ -537,7 +537,7 @@ jobs:
   #  Clean-up  #
   ##############
   clean-up:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: always()
     needs: [tc-gcc, tc-llvm, riscv-isa-sim, verilator, tc-halide, verilator-model,
       build-apps-llvm, build-apps-gcc, build-apps-halide, unit-test, run-apps-gcc,
@@ -554,7 +554,7 @@ jobs:
           verilator
 
   clean-up-compile-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: always()
     needs: [tc-gcc, tc-llvm, riscv-isa-sim, verilator, tc-halide, verilator-model,
       build-apps-llvm, build-apps-gcc, build-apps-halide, unit-test, run-apps-gcc,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   # Check License #
   #################
   check-license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Install Python requirements
@@ -25,7 +25,7 @@ jobs:
   # Check C/C++ files for correct formatting.
   clangfmt:
     name: C/C++ Sources
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: DoozyX/clang-format-lint-action@v0.14
@@ -37,7 +37,7 @@ jobs:
   ########################
   python:
     name: Python Sources
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Install Python requirements
@@ -51,7 +51,7 @@ jobs:
   # Check Trailing Spaces #
   #########################
   check-trailing-whitespaces:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -11,13 +11,12 @@ variables:
   RUST_LOG: 'memora=debug'
   VERILATOR_ROOT: '$CI_PROJECT_DIR/install/verilator'
   CLANG_PATH: '/usr/pack/llvm-10.0.1-af'
-  PATH: '/home/gitlabci/.cargo/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/condor/bin:/usr/sepp/bin:$VERILATOR_ROOT/bin'
+  PATH: '/home/gitlabci/miniconda3/condabin:/home/gitlabci/.cargo/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/condor/bin:/usr/sepp/bin:$VERILATOR_ROOT/bin'
   OBJCACHE: ''
   RISCV_WARNINGS: '-Werror'
   CC: 'gcc-8.2.0'
   CXX: 'g++-8.2.0'
   CMAKE: 'cmake-3.18.1'
-  python: 'python3.6'
 
 workflow:
   rules:
@@ -27,6 +26,8 @@ workflow:
 
 before_script:
   - env
+  - source /home/gitlabci/miniconda3/etc/profile.d/conda.sh
+  - conda activate mempool
 
 stages:
   - tools
@@ -67,11 +68,9 @@ verilator:
   stage: tools
   script:
     # The CI's ccache directory is very limited in size, so let's disable it.
-    # Verilator requires a more recent version of python than the default one.
     - |
       if ! $CI_PROJECT_DIR/scripts/memora_retry.sh lookup verilator; then
         git submodule update --init --recursive -- toolchain/verilator
-        export PYTHON3=$(which python3-3.6.5)
         export VERILATOR_CI="--disable-defenv"
         make verilator
         $CI_PROJECT_DIR/scripts/memora_retry.sh insert verilator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support multiple outstanding wake-up calls in Snitch
 - Clean out tracing script and improve the traces' size and checks
 - Replace NUM_CORES and similar macros with function calls in software
+- Fix CI runner to Ubuntu 20.04 and Python to version 3.8
 
 ## 0.5.0 - 2022-08-03
 

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -2,9 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-bin2coe
 dataclasses
-editorconfig-checker
 flake8
 gitpython
 hjson
@@ -15,4 +13,3 @@ numpy
 pandas
 progressbar2
 tabulate
-yamlfmt


### PR DESCRIPTION
Fix GitHub and GitLab's CI.

**GitHub**: Since GitHub upgraded their latest Ubuntu version to 22.04, our Python packages can not be installed, and Verilator does not build. Both need to be addressed at some point, but for now, we can just specify the previous Ubuntu version, which is 20.04.

**GitLab**: Multiple users using the same GitLab runner on machines with different OS versions led to python packages not being compatible. The cleanest solution is to use a Conda environment for MemPool to separate our Python packages from other users.

Both CIs also work after cleaning out all the caches.

## Changelog

### Changed
- Fix CI runner to Ubuntu 20.04 and Python to version 3.8

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
