### PR TITLE
Extended tracevis.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## Changes
+- Extended `tracevis.py` to support the new Perfetto UI and compress large traces
+
 ## 0.6.0 - 2023-01-09
 
 ### Added


### PR DESCRIPTION
I had problems to visualize large traces (>1 GB) generated with Banshee with the `about:tracing` functionality in Google Chrome. To tackle this problem, I extended the `tracevis.py` script to support the new [Perfetto UI](https://ui.perfetto.dev/) and added the option to compress the traces by only showing the function name instead of every single instruction.

Additionally, I implemented the option to information captured sections between `mempool_start_benchmark()` and `mempool_stop_benchmark()` only. This is particularly relevant for Banshee traces.

Backward compatibility with the about:tracing feature in Google Chrome is still maintained.

## Changelog

### Added
- Support the new [Perfetto UI](https://ui.perfetto.dev/)
- Support compression of large traces by extracting the function and only display them
- Support filtering calls between  `mempool_start_benchmark()` and `mempool_stop_benchmark()` calls

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

## Appendix
**Google Chrome Trace-Viewer**
JSON Trace Size: 44 MB
![image](https://user-images.githubusercontent.com/1339834/211825123-47fd0d79-7f7f-4e13-804a-7f772e386a70.png)

**Perfetto UI (Enabled filtering)**
JSON Trace Size: 39 MB
![image](https://user-images.githubusercontent.com/1339834/211824087-952ad21a-7274-48e8-8dd0-10f695868a0c.png)

**Perfetto UI (Enabled functions extraction and filtering)**
JSON Trace Size: 52 kB
![image](https://user-images.githubusercontent.com/1339834/211824166-109ba53e-f6da-4707-b6a9-22bb302e17b6.png)


