### PR TITLE
Hardware updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Implement operand gating for SIMD and MAC Units in Snitch IPU's DSP Unit
 - Add Channel Estimation application and kernels
 - Update Bender to version 0.27.3
+- Update default Questasim version to 2022.3
 
 ### Fixed
 - Fix type issue in `snitch_addr_demux`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use custom compiler for VCS specified with `CC` and `CCX` environment variable
 - Implement operand gating for SIMD and MAC Units in Snitch IPU's DSP Unit
 - Add Channel Estimation application and kernels
+- Update Bender to version 0.27.3
 
 ### Fixed
 - Fix type issue in `snitch_addr_demux`

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 ifeq ($(origin CXX),default)
   CXX = g++
 endif
-BENDER_VERSION = 0.23.2
+BENDER_VERSION = 0.27.3
 
 # We need a recent LLVM installation (>11) to compile Verilator.
 # We also need to link the binaries with LLVM's libc++.

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -25,7 +25,7 @@ dpi_library     ?= work-dpi
 # Top level module to compile
 top_level       ?= mempool_tb
 # QuestaSim Version
-questa_version  ?= 2021.2-bt
+questa_version  ?= 2022.3-bt
 # QuestaSim command
 questa_cmd      ?= questa-$(questa_version)
 # QuestaSim arguments

--- a/hardware/deps/idma/Bender.yml
+++ b/hardware/deps/idma/Bender.yml
@@ -4,9 +4,10 @@ package:
     - "Thomas Benz <tbenz@iis.ee.ethz.ch>" # current maintainer
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
-  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
-  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.29.1 }
+  axi:                 { git: "https://github.com/pulp-platform/axi.git",                 version: 0.29.1 }
+  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.21.0 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0  }
+  register_interface:  { git: "https://github.com/pulp-platform/register_interface.git",  version: 0.3.1  }
 
 sources:
   # Source files grouped in levels. Files in level 0 have no dependencies on files in this

--- a/hardware/deps/snitch/Bender.yml
+++ b/hardware/deps/snitch/Bender.yml
@@ -7,6 +7,7 @@ package:
   authors: [ "Florian Zaruba <zarubaf@iis.ee.ethz.ch>" ]
 
 dependencies:
+  axi:          { git: "https://github.com/pulp-platform/axi.git",          version: 0.36.0 }
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.19.0 }
 
 sources:


### PR DESCRIPTION
Update Bender and Questasim to their latest version.

- The previous Bender version did not provide a ready release for our machines (@Xeratec)
- The previous Questasim version did not print the traces correctly on newer machines

## Changelog

### Changed
- Update Bender to version 0.27.3
- Update default Questasim version to 2022.3

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed