### PR TITLE
Performance metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update default Questasim version to 2022.3
 - Decrease stack size to 128 words
 - Add CFFT radix-4 and radix-2 kernels
+- Parametrize the performance counters
 
 ### Fixed
 - Fix type issue in `snitch_addr_demux`
+- Properly disable the debugging CSRs in ASIC implementations
 
 ## 0.6.0 - 2023-01-09
 

--- a/hardware/deps/snitch/Bender.yml
+++ b/hardware/deps/snitch/Bender.yml
@@ -13,6 +13,7 @@ dependencies:
 sources:
   - defines:
       SNITCH_ENABLE_PERF: 1
+      SNITCH_ENABLE_STALL_COUNTER: 1
     files:
     # packages
     - src/riscv_instr.sv

--- a/hardware/scripts/questa/wave.tcl
+++ b/hardware/scripts/questa/wave.tcl
@@ -5,6 +5,26 @@
 onerror {resume}
 quietly WaveActivateNextPane {} 0
 
+# Add a vector of the core's utilization signals to quickly get an overview of the systems activity
+set num_cores [examine -radix dec mempool_pkg::NumCores]
+
+add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $num_cores -radix unsigned /mempool_tb/snitch_utilization
+add wave -noupdate -group Utilization /mempool_tb/instruction_handshake
+add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $num_cores -radix unsigned /mempool_tb/lsu_utilization
+add wave -noupdate -group Utilization /mempool_tb/lsu_handshake
+add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $num_cores -radix unsigned /mempool_tb/lsu_pressure
+add wave -noupdate -group Utilization /mempool_tb/lsu_request
+if {[examine -radix dec /snitch_pkg::XPULPIMG]} {
+  add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $num_cores -radix unsigned /mempool_tb/gen_utilization/dspu_utilization
+  add wave -noupdate -group Utilization /mempool_tb/gen_utilization/dspu_handshake
+  add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $num_cores -radix unsigned /mempool_tb/gen_utilization/mac_utilization
+  add wave -noupdate -group Utilization /mempool_tb/gen_utilization/dspu_mac
+}
+set axi_channels [expr [examine -radix dec mempool_pkg::NumGroups] * [examine -radix dec mempool_pkg::NumAXIMastersPerGroup]]
+add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $axi_channels -radix unsigned /mempool_tb/axi_w_utilization
+add wave -noupdate -group Utilization -color {Cornflower Blue} -format Analog-Step -height 84 -max $axi_channels -radix unsigned /mempool_tb/axi_r_utilization
+
+
 # Add a vector of the core's wfi signal to quickly see which cores are active
 add wave /mempool_tb/wfi
 


### PR DESCRIPTION
Disable the simulation-only debugging CSRs (tracing, stack-overflow warning) and parameterize the stall counter performance registers. Also, add some waves to easier debug and benchmark on MemPool by visualizing performance in real-time. I added some default ones and more additional ones are welcome.

![waves](https://github.com/pulp-platform/mempool/assets/19757972/164b7317-ceb7-49d9-9fa2-f020ed6b43f7)

## Changelog

### Changed
- Parametrize the performance counters

### Fixed
- Properly disable the debugging CSRs in ASIC implementations

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed