### PR TITLE
[ci] Run the CI daily on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: ci
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run the CI on the main branch every morning at 01:19 UTC
+    - cron:  '19 1 * * *'
 
 jobs:
 


### PR DESCRIPTION
This has two benefits: First, we ensure that the main branch works even if the runners/dependencies update. Second, GitHub's caches are scoped. They only work among commits of the same branch, except from the default branch. (https://github.com/actions/cache#cache-scopes) Therefore, if we ensure that the main branch is always cached, we should always hit the caches and have quick turnaround times on all our branches and PRs.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed