### PR TITLE
[halide] Upgrade Halide to 15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `common_cells` to 1.33.0
 - Update `common_verification` to 0.2.3
 - Update `register_interface` to 0.4.3
+- Updated Halide to version 15
 
 ### Fixed
 - Fix type issue in `snitch_addr_demux`


### PR DESCRIPTION
Upgrade Halide to support our latest LLVM version. This PR will fix the pipeline of the upcoming FPU merge.

Fixes this pipeline:
- [Fails](https://github.com/pulp-platform/mempool/actions/runs/8007526290)
- [Works](https://github.com/pulp-platform/mempool/actions/runs/8020360672)

## Changelog

### Changed
- Updated Halide to version 15

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed