### PR TITLE
Stabilize LSU interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Parametrize the performance counters
 - Restructure the software folder by moving kernels, data, and tests to dedicated folders
 - Add Channel Estimation based on multiplication by (1 / pilot)
+- Gate the LSU output to ensure a stable handshake interface and save energy
 
 ### Fixed
 - Fix type issue in `snitch_addr_demux`


### PR DESCRIPTION
Gate the LSU operands not required for the current operation (e.g., write data for a read) to ensure stability during a handshake. Furthermore, choose a fixed ID at the request time to guarantee that the request ID will not change while waiting for the ready signal. This could happen if a response freed a new ID while a request was outstanding.

Note that this does not fix any bugs since MemPool's interconnect does not require the stability guarantee, but it patches a pitfall that could be hard to debug later and improves energy efficiency.

## Changelog

### Changed
- Gate the LSU output to ensure a stable handshake interface and save energy

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed