### PR TITLE
Udate to latest GitHub CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
   tc-gcc:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Recover the submodule commit hash
       run: |
         git rev-parse HEAD:toolchain/riscv-gnu-toolchain
         echo "riscv-gnu-toolchain-hash=`git rev-parse HEAD:toolchain/riscv-gnu-toolchain`" >> $GITHUB_ENV
     - name: Cache riscv-gnu-toolchain
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: riscv-gnu-toolchain
       with:
         path: install/riscv-gcc
@@ -40,7 +40,7 @@ jobs:
     - name: Tar riscv-gnu-toolchain
       run: tar --posix --use-compress-program zstd -cf riscv-gnu-toolchain.tzst install/riscv-gcc
     - name: Upload riscv-gnu-toolchain
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: riscv-gnu-toolchain
         path: riscv-gnu-toolchain.tzst
@@ -48,13 +48,13 @@ jobs:
   tc-llvm:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Recover the submodule commit hash
       run: |
         git rev-parse HEAD:toolchain/llvm-project
         echo "llvm-project-hash=`git rev-parse HEAD:toolchain/llvm-project`" >> $GITHUB_ENV
     - name: Cache llvm-project
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: llvm-project
       with:
         path: install/llvm
@@ -69,7 +69,7 @@ jobs:
     - name: Tar llvm-project
       run: tar --posix --use-compress-program zstd -cf llvm-project.tzst install/llvm
     - name: Upload llvm-project
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: llvm-project
         path: llvm-project.tzst
@@ -78,20 +78,20 @@ jobs:
     runs-on: ubuntu-20.04
     needs: tc-llvm
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Recover the submodule commit hash
       run: |
         git rev-parse HEAD:toolchain/halide
         echo "halide-hash=`git rev-parse HEAD:toolchain/halide`" >> $GITHUB_ENV
     - name: Cache halide
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: halide
       with:
         path: install/halide
         key: ${{ runner.os }}-halide-${{ env.halide-hash }}
     - name: Get llvm-project artifacts
       if: steps.halide.outputs.cache-hit != 'true'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llvm-project
     - name: Untar llvm-project
@@ -107,7 +107,7 @@ jobs:
     - name: Tar halide
       run: tar --posix --use-compress-program zstd -cf halide.tzst install/halide
     - name: Upload halide
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: halide
         path: halide.tzst
@@ -118,9 +118,9 @@ jobs:
   riscv-isa-sim:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Cache riscv-isa-sim
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: riscv-isa-sim
       with:
         path: install/riscv-isa-sim
@@ -136,7 +136,7 @@ jobs:
     - name: Tar riscv-isa-sim
       run: tar --posix --use-compress-program zstd -cf riscv-isa-sim.tzst install/riscv-isa-sim
     - name: Upload riscv-isa-sim
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: riscv-isa-sim
         path: riscv-isa-sim.tzst
@@ -144,13 +144,13 @@ jobs:
   verilator:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Recover the submodule commit hash
       run: |
         git rev-parse HEAD:toolchain/verilator
         echo "tc-verilator-hash=`git rev-parse HEAD:toolchain/verilator`" >> $GITHUB_ENV
     - name: Cache Verilator
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: verilator-cache
       with:
         path: install/verilator
@@ -167,7 +167,7 @@ jobs:
     - name: Tar verilator
       run: tar --posix --use-compress-program zstd -cf verilator.tzst install/verilator
     - name: Upload verilator
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: verilator
         path: verilator.tzst
@@ -183,16 +183,16 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Cache Verilator Model
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: verilator-model
       with:
         path: hardware/verilator_build/Vmempool_tb_verilator
         key: ${{ runner.os }}-verilator-model-${{ matrix.mempool_config }}-${{ hashFiles('hardware/**','config/**') }}
     - name: Get Verilator artifacts
       if: steps.verilator-model.outputs.cache-hit != 'true'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: verilator
     - name: Untar Verilator
@@ -212,7 +212,7 @@ jobs:
     - name: Tar Verilator Model
       run: tar --posix --use-compress-program zstd -cf verilator-model.tzst hardware/verilator_build/Vmempool_tb_verilator
     - name: Upload Verilator Model
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: verilator-model-${{ matrix.mempool_config }}
         path: verilator-model.tzst
@@ -224,9 +224,9 @@ jobs:
     runs-on: ubuntu-20.04
     needs: tc-gcc
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get riscv-gnu-toolchain artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-gnu-toolchain
     - name: Untar riscv-gnu-toolchain
@@ -242,7 +242,7 @@ jobs:
   check-opcodes:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Regenerate opcodes
       run: |
         make update_opcodes
@@ -258,9 +258,9 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get riscv-gnu-toolchain artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-gnu-toolchain
     - name: Untar riscv-gnu-toolchain
@@ -276,7 +276,7 @@ jobs:
     - name: Tar apps-gcc Model
       run: tar --posix --use-compress-program zstd -cf apps-gcc.tzst software/bin
     - name: Upload apps-gcc
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: apps-gcc-${{ matrix.mempool_config }}
         path: apps-gcc.tzst
@@ -288,15 +288,15 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get riscv-gnu-toolchain artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-gnu-toolchain
     - name: Untar riscv-gnu-toolchain
       run: tar --use-compress-program zstd -xf riscv-gnu-toolchain.tzst
     - name: Get llvm-project artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llvm-project
     - name: Untar llvm-project
@@ -312,7 +312,7 @@ jobs:
     - name: Tar apps-llvm Model
       run: tar --posix --use-compress-program zstd -cf apps-llvm.tzst software/bin
     - name: Upload apps-llvm
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: apps-llvm-${{ matrix.mempool_config }}
         path: apps-llvm.tzst
@@ -324,21 +324,21 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get riscv-gnu-toolchain artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-gnu-toolchain
     - name: Untar riscv-gnu-toolchain
       run: tar --use-compress-program zstd -xf riscv-gnu-toolchain.tzst
     - name: Get llvm-project artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llvm-project
     - name: Untar llvm-project
       run: tar --use-compress-program zstd -xf llvm-project.tzst
     - name: Get halide artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: halide
     - name: Untar halide
@@ -352,7 +352,7 @@ jobs:
     - name: Tar apps-halide Model
       run: tar --posix --use-compress-program zstd -cf apps-halide.tzst software/bin
     - name: Upload apps-halide
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: apps-halide-${{ matrix.mempool_config }}
         path: apps-halide.tzst
@@ -368,21 +368,21 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get apps-gcc artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: apps-gcc-${{ matrix.mempool_config }}
     - name: Untar apps-gcc
       run: tar --use-compress-program zstd -xf apps-gcc.tzst
     - name: Get riscv-isa-sim artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-isa-sim
     - name: Untar riscv-isa-sim
       run: tar --use-compress-program zstd -xf riscv-isa-sim.tzst
     - name: Get verilator-model artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: verilator-model-${{ matrix.mempool_config }}
     - name: Untar verilator-model
@@ -406,21 +406,21 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get apps-llvm artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: apps-llvm-${{ matrix.mempool_config }}
     - name: Untar apps-llvm
       run: tar --use-compress-program zstd -xf apps-llvm.tzst
     - name: Get riscv-isa-sim artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-isa-sim
     - name: Untar riscv-isa-sim
       run: tar --use-compress-program zstd -xf riscv-isa-sim.tzst
     - name: Get verilator-model artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: verilator-model-${{ matrix.mempool_config }}
     - name: Untar verilator-model
@@ -444,21 +444,21 @@ jobs:
       matrix:
         mempool_config: [minpool, mempool]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get apps-halide artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: apps-halide-${{ matrix.mempool_config }}
     - name: Untar apps-halide
       run: tar --use-compress-program zstd -xf apps-halide.tzst
     - name: Get riscv-isa-sim artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-isa-sim
     - name: Untar riscv-isa-sim
       run: tar --use-compress-program zstd -xf riscv-isa-sim.tzst
     - name: Get verilator-model artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: verilator-model-${{ matrix.mempool_config }}
     - name: Untar verilator-model
@@ -479,21 +479,21 @@ jobs:
     timeout-minutes: 10
     needs: [tc-gcc, riscv-isa-sim, verilator-model]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get riscv-gnu-toolchain artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-gnu-toolchain
     - name: Untar riscv-gnu-toolchain
       run: tar --use-compress-program zstd -xf riscv-gnu-toolchain.tzst
     - name: Get riscv-isa-sim artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: riscv-isa-sim
     - name: Untar riscv-isa-sim
       run: tar --use-compress-program zstd -xf riscv-isa-sim.tzst
     - name: Get verilator-model artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: verilator-model-minpool
     - name: Untar verilator-model
@@ -521,7 +521,7 @@ jobs:
       run-apps-llvm, run-apps-halide]
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v4
       with:
         name: |
           riscv-gnu-toolchain
@@ -541,7 +541,7 @@ jobs:
         mempool_config: [minpool, mempool]
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v4
       with:
         name: |
           verilator-model-${{ matrix.mempool_config }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   check-license:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Python requirements
       run: pip install -r python-requirements.txt
     - name: Check license
@@ -27,7 +27,7 @@ jobs:
     name: C/C++ Sources
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         clangFormatVersion: 14
@@ -39,7 +39,7 @@ jobs:
     name: Python Sources
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Python requirements
       run: pip install flake8
     # Check that all python sources conform to the `pep8` standard
@@ -53,7 +53,7 @@ jobs:
   check-trailing-whitespaces:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Determine base commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Restructure the software folder by moving kernels, data, and tests to dedicated folders
 - Add Channel Estimation based on multiplication by (1 / pilot)
 - Gate the LSU output to ensure a stable handshake interface and save energy
+- Update to the latest GitHub CI actions
 
 ### Fixed
 - Fix type issue in `snitch_addr_demux`


### PR DESCRIPTION
Update the GitHub actions from v3 to v4 as suggested by GitHub. See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## Changelog

### Changed
- Update to the latest GitHub CI actions

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed