### PR TITLE
Add Back2Local routing and benchmark analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tags
 # Python
 **.idea
 venv
+__pycache__/
 # Visual Studio Code
 .vscode
 *.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support for DRAMsys5.0 co-simulation
 - Add support for atomics in L2
 - Add Dynamic Address Scrambling (DAS) support with configurable partitioning, hardware address scrambler, and software runtime for dynamic heap allocation
+- Add Back2Local rerouting mechanism and interconnect extensions to use underutilized tile ports and increase TCDM bandwidth for local accesses
 
 ### Changes
 - Add physical feasible TeraPool configuration with SubGroup hierarchy.

--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ app=hello_world make simc
 make trace
 # Generate a visualization of the traces
 app=hello_world make tracevis
-# Automatically run the benchmark (headless), extract the traces, and log the results
-app=hello_world make benchmark
+# Benchmark and plot an app bracketed by mempool_start_benchmark() and
+# mempool_stop_benchmark(); see hardware/scripts/trace_analysis/README.md.
+app=matmul_i32 make benchmark
+app=matmul_i32 make plots
 ```
 
 You can set up the configuration of the system in the file `config/config.mk`, controlling the total number of cores, the number of cores per tile and whether the Xpulpimg extension is enabled or not in the Snitch core; the `xpulpimg` parameter also control the default core architecture considered when compiling applications for MemPool.

--- a/config/README.md
+++ b/config/README.md
@@ -37,13 +37,18 @@ git update-index --no-assume-unchanged config/config.mk
 
 ## Back2Local
 
-Back2Local reuses group-level tile ports for TCDM requests that remain in the
-source group. It changes the route to memory, not the address mapping, and can
-be used with or without DAS.
+Back2Local reuses upper-level tile ports for TCDM requests that remain in the
+source group or subgroup. It changes the route to memory, not the address
+mapping, and can be used with or without DAS.
 
-| Variable     | Default | Description                              |
-|--------------|---------|------------------------------------------|
-| `back2local` | `0`     | Enable Back2Local for the selected setup |
+| Variable                | Default | Description                                |
+|-------------------------|---------|--------------------------------------------|
+| `back2local`            | `0`     | Enable Back2Local for the selected setup   |
+| `back2local_tera_group` | `0`     | Also use TeraPool's group-level tile ports |
+
+For TeraPool, `back2local=1` uses the subgroup-level ports by default. Setting
+`back2local_tera_group=1` also makes the group-level ports available and may
+contend with inter-group traffic.
 
 The current port selection uses the core index modulo the available ports. It
 is a simple baseline policy that can be adapted in

--- a/config/README.md
+++ b/config/README.md
@@ -35,6 +35,20 @@ you can use the following command to make git pick up tracking the file again:
 git update-index --no-assume-unchanged config/config.mk
 ```
 
+## Back2Local
+
+Back2Local reuses group-level tile ports for TCDM requests that remain in the
+source group. It changes the route to memory, not the address mapping, and can
+be used with or without DAS.
+
+| Variable     | Default | Description                              |
+|--------------|---------|------------------------------------------|
+| `back2local` | `0`     | Enable Back2Local for the selected setup |
+
+The current port selection uses the core index modulo the available ports. It
+is a simple baseline policy that can be adapted in
+`hardware/src/mempool_tile.sv`.
+
 ## Dynamic Address Scrambling (DAS)
 
 Dynamic Address Scrambling (DAS) is a runtime-configurable address mapping

--- a/config/config.mk
+++ b/config/config.mk
@@ -79,6 +79,11 @@ num_das_partitions ?= 4
 # Size of DAS-heap per core
 das_mem_size ?= 2048
 
+# Enable Back2Local rerouting for the selected topology.
+# The core-index modulo port selection in mempool_tile.sv is a placeholder,
+# not an optimized routing policy. Adapt it to the target traffic pattern.
+back2local ?= 0
+
 # This parameter is only used for TeraPool configurations
 num_sub_groups_per_group ?= 1
 remote_group_latency_cycles ?= 7

--- a/config/terapool.mk
+++ b/config/terapool.mk
@@ -30,6 +30,11 @@ num_divsqrt_per_tile ?= 2
 # L1 scratchpad banking factor
 banking_factor ?= 4
 
+# Also use group-level ports for same-subgroup Back2Local requests.
+# Requires back2local=1 and more than one subgroup per group. This may
+# contend with inter-group traffic.
+back2local_tera_group ?= 0
+
 # Access latency between remote groups
 # Options: "7", "9" or "11":
 remote_group_latency_cycles ?= 7

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -127,9 +127,12 @@ vlog_defs   += -DNUM_DAS_PARTITIONS=$(num_das_partitions)
 ifeq ($(das),1)
 vlog_defs   += -DDAS_MEM_SIZE=$(das_mem_size)
 endif
-ifeq ($(config),mempool)
 ifeq ($(back2local),1)
 vlog_defs   += -DBACK2LOCAL
+ifeq ($(config),terapool)
+ifeq ($(back2local_tera_group),1)
+vlog_defs   += -DBACK2LOCAL_TERA_GROUP
+endif
 endif
 endif
 # Snitch ISA

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -120,6 +120,9 @@ vlog_defs   += -DL1_BANK_SIZE=$(l1_bank_size)
 vlog_defs   += -DBOOT_ADDR=32\'d$(boot_addr)
 vlog_defs   += -DDAS=$(das)
 vlog_defs   += -DNUM_DAS_PARTITIONS=$(num_das_partitions)
+ifeq ($(das),1)
+vlog_defs   += -DDAS_MEM_SIZE=$(das_mem_size)
+endif
 ifeq ($(config),mempool)
 ifeq ($(back2local),1)
 vlog_defs   += -DBACK2LOCAL

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -48,6 +48,8 @@ python          ?= python3
 buildpath       ?= build
 # Result path
 resultpath      ?= results
+# Two-stage benchmark/plotting workflow; see scripts/trace_analysis/README.md.
+include $(ROOT_DIR)/scripts/trace_analysis/benchmark.mk
 result_dir      := $(if $(strip $(result_dir)),$(result_dir),$(resultpath)/$(shell date +"%Y%m%d_%H%M%S_$(app)_$$(git rev-parse --short HEAD)"))
 # Traces
 snitch_trace    ?= 1
@@ -67,6 +69,7 @@ questa_args += -sv_lib $(dramsys_lib_path)/libsystemc -sv_lib $(dramsys_lib_path
 app_path ?= $(abspath $(ROOT_DIR)/../software/bin)
 ifdef app
   preload := "$(app_path)/$(app)"
+  ifeq ($(skip_app_validation),)
   ifeq ("$(shell test -f $(preload))","")
     # The file doesn't exist, let's search for the app in the bin folder
     # since we might just be missing the hierarchy
@@ -80,6 +83,7 @@ ifdef app
     else
       $(error "Multiple apps ($(app)) found in bin dir $(app_path): $(search_app)")
     endif
+  endif
   endif
 endif
 
@@ -134,6 +138,9 @@ vlog_defs   += -DZFINX=$(zfinx)
 vlog_defs   += -DZQUARTERINX=$(zquarterinx)
 vlog_defs   += -DXDIVSQRT=$(xDivSqrt)
 vlog_defs   += -DSNITCH_TRACE=$(snitch_trace)
+ifeq ($(tcdm_addr_trace),1)
+vlog_defs   += -DTCDM_ADDR_TRACE
+endif
 # AXI & DMA
 vlog_defs   += -DAXI_DATA_WIDTH=$(axi_data_width)
 vlog_defs   += -DRO_LINE_WIDTH=$(ro_line_width)
@@ -263,7 +270,7 @@ simvcs: compile_vcs_simv
 	cd $(buildpath) && \
 	./mempool_simv $(vcs_args) -ucli -do ../scripts/vcs/run.tcl -gui
 
-simcvcs: compile_vcs_simvopt
+simcvcs: clean-dasm compile_vcs_simvopt
 	cd $(buildpath) && \
 	./mempool_simvopt $(vcs_args)
 
@@ -367,24 +374,51 @@ spyglass/tmp/files: $(bender)
 
 # Give configuration in env
 trace_env += NUM_CORES=$(num_cores)
+trace_env += NUM_CORES_PER_TILE=$(num_cores_per_tile)
 trace_env += SEQ_MEM_SIZE=$(seq_mem_size)
+trace_env += BANKING_FACTOR=$(banking_factor)
+trace_env += L1_BANK_SIZE=$(l1_bank_size)
+
+# Per-hart CSV parts, merged by post_trace; `make benchmark` skips the
+# .trace copies into result_dir (copy_traces=0).
+tracepartspath ?= $(tracepath)/results_parts
+copy_traces    ?= 1
 
 trace: pre_trace $(trace) post_trace
 
+# Order pre_trace -> per-hart traces -> post_trace under `make -j`.
+$(trace): | pre_trace
+post_trace: $(trace)
+
 pre_trace:
 	rm -rf $(tracepath)
+	rm -f $(buildpath)/trace_hart_*.trace
 
 post_trace:
 	mkdir -p "$(result_dir)"
 	cp $(buildpath)/transcript "$(result_dir)/" | true
+	$(python) $(ROOT_DIR)/scripts/merge_trace_csvs.py \
+		--folder "$(tracepartspath)" \
+		--expected-count "$(words $(trace))" \
+		--csv "$(traceresult)"
 	cp $(traceresult) "$(result_dir)"
+ifeq ($(copy_traces),1)
 	cp $(trace) "$(result_dir)"
+endif
 	$(python) $(ROOT_DIR)/scripts/gen_avg.py --folder "$(result_dir)" | tee $(result_dir)/avg.txt
 
 $(buildpath)/%.trace: $(buildpath)/%.dasm
-	mkdir -p $(tracepath)
+	mkdir -p $(tracepath) $(tracepartspath)
+ifeq ($(tcdm_addr_trace),1)
+	$(INSTALL_DIR)/riscv-isa-sim/bin/spike-dasm < $< > $(tracepath)/$*.raw
+	$(python) $(ROOT_DIR)/scripts/merge_tcdm_trace.py \
+		$(tracepath)/$*.raw $(buildpath)/tcdm_addr_hart_$(patsubst trace_hart_%,%,$*).csv \
+		> $(tracepath)/$*
+	rm -f $(tracepath)/$*.raw
+else
 	$(INSTALL_DIR)/riscv-isa-sim/bin/spike-dasm < $< > $(tracepath)/$*
-	$(trace_env) $(python) $(ROOT_DIR)/scripts/gen_trace.py -p --csv $(traceresult) $(tracepath)/$* > $@
+endif
+	$(trace_env) $(python) $(ROOT_DIR)/scripts/gen_trace.py -p --csv $(tracepartspath)/$*.csv $(tracepath)/$* > $@
 
 tracevis:
 	$(MEMPOOL_DIR)/scripts/tracevis.py $(preload) $(buildpath)/*.trace -o $(buildpath)/tracevis.json
@@ -443,7 +477,7 @@ clean:
 	@rm -rf $(verilator_build)
 
 clean-dasm:
-	rm -rf $(buildpath)/*.dasm
+	rm -rf $(buildpath)/*.dasm $(buildpath)/tcdm_addr_hart_*.csv
 
 clean-trace:
 	rm -rf $(buildpath)/*.trace

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -120,6 +120,11 @@ vlog_defs   += -DL1_BANK_SIZE=$(l1_bank_size)
 vlog_defs   += -DBOOT_ADDR=32\'d$(boot_addr)
 vlog_defs   += -DDAS=$(das)
 vlog_defs   += -DNUM_DAS_PARTITIONS=$(num_das_partitions)
+ifeq ($(config),mempool)
+ifeq ($(back2local),1)
+vlog_defs   += -DBACK2LOCAL
+endif
+endif
 # Snitch ISA
 vlog_defs   += -DXPULPIMG=$(xpulpimg)
 vlog_defs   += -DZFINX=$(zfinx)

--- a/hardware/deps/idma/src/midends/idma_address_scrambler.sv
+++ b/hardware/deps/idma/src/midends/idma_address_scrambler.sv
@@ -17,6 +17,7 @@ module idma_address_scrambler #(
   parameter int unsigned NumTiles          = 128,
   parameter int unsigned NumBanksPerTile   = 32,
   parameter int unsigned TCDMSizePerBank   = 1024,
+  parameter int unsigned RowsInterleavingWidth = $clog2(TCDMSizePerBank) - ByteOffset,
   parameter int unsigned NumDASPartitions  = 4,
   parameter int unsigned DASStartAddr      = 1024,
   parameter int unsigned MemSizePerTile    = NumBanksPerTile*TCDMSizePerBank,
@@ -25,10 +26,10 @@ module idma_address_scrambler #(
   input  logic [AddrWidth-1:0]                            address_i,
   input  logic [31:0]                                     num_bytes_i,
   input  logic [NumDASPartitions-1:0][$clog2(NumTiles):0] tiles_das_i,
-  input  logic [NumDASPartitions-1:0][$clog2(NumTiles):0] rows_das_i,
+  input  logic [NumDASPartitions-1:0][RowsInterleavingWidth-1:0] rows_das_i,
   input  logic [NumDASPartitions-1:0][DataWidth-1:0]      start_das_i,
   output logic [$clog2(NumTiles):0]                       tiles_das_o,
-  output logic [$clog2(NumTiles):0]                       rows_das_o,
+  output logic [RowsInterleavingWidth:0]                  rows_das_o,
   output logic [AddrWidth-1:0]                            address_o
 );
   // Basic Settings
@@ -45,7 +46,7 @@ module idma_address_scrambler #(
     // `tile_index` : how many bits to shift for TileID bits in each partition
     // `row_index`: how many bits need to swap within Row Index
     logic [NumDASPartitions-1:0][$clog2($clog2(NumTiles)+1)-1:0] tile_index;
-    logic [NumDASPartitions-1:0][$clog2($clog2(NumTiles)+1)-1:0] row_index;
+    logic [NumDASPartitions-1:0][$clog2(RowsInterleavingWidth)-1:0] row_index;
 
     for (genvar i = 0; i < NumDASPartitions; i++) begin : gen_shift_index
       lzc #(
@@ -57,12 +58,12 @@ module idma_address_scrambler #(
         .empty_o (/* Unused */     )
       );
       lzc #(
-        .WIDTH ($clog2(NumTiles)+1),
+        .WIDTH (RowsInterleavingWidth),
         .MODE  (1'b0            )
       ) i_log_row_index (
-        .in_i    (rows_das_i[i][$clog2(NumTiles):0]),
-        .cnt_o   (row_index[i]                           ),
-        .empty_o (/* Unused */                           )
+        .in_i    (rows_das_i[i]),
+        .cnt_o   (row_index[i] ),
+        .empty_o (/* Unused */  )
       );
     end
 

--- a/hardware/deps/idma/src/midends/idma_distributed_midend.sv
+++ b/hardware/deps/idma/src/midends/idma_distributed_midend.sv
@@ -20,8 +20,8 @@ module idma_distributed_midend #(
   /// Number of generic 1D requests that can be buffered
   parameter int unsigned TransFifoDepth = 1,
 `ifdef DAS
-  parameter int unsigned NumTiles          = 64,
   parameter int unsigned NumDASPartitions  = 4,
+  parameter int unsigned RowsWidth,
 `endif
   /// Arbitrary 1D burst request definition
   parameter type         burst_req_t    = logic,
@@ -32,7 +32,7 @@ module idma_distributed_midend #(
   input  logic                            rst_ni,
 `ifdef DAS
   // DAS signals
-  input  logic       [$clog2(NumTiles):0] rows_das_i,
+  input  logic       [RowsWidth-1:0] rows_das_i,
 `endif
   // Slave
   input  burst_req_t                      burst_req_i,

--- a/hardware/deps/idma/src/midends/idma_split_midend.sv
+++ b/hardware/deps/idma/src/midends/idma_split_midend.sv
@@ -17,6 +17,7 @@ module idma_split_midend #(
   parameter int unsigned NumTiles          = 64,
   parameter int unsigned NumBanksPerTile   = 32,
   parameter int unsigned TCDMSizePerBank   = 1024,
+  parameter int unsigned RowsInterleavingWidth = $clog2(TCDMSizePerBank) - 2,
   parameter int unsigned NumDASPartitions  = 4,
   parameter int unsigned DASStartAddr      = 1024,
   parameter int unsigned NumTilesPerDma    = 16,
@@ -30,8 +31,8 @@ module idma_split_midend #(
   // DAS signals
   input  logic [NumDASPartitions-1:0][$clog2(NumTiles):0] tiles_das_i,
   input  logic [NumDASPartitions-1:0][AddrWidth-1:0]      start_das_i,
-  input  logic [NumDASPartitions-1:0][$clog2(NumTiles):0] rows_das_i,
-  output logic [$clog2(NumTiles):0]                       rows_das_o,
+  input  logic [NumDASPartitions-1:0][RowsInterleavingWidth-1:0] rows_das_i,
+  output logic [RowsInterleavingWidth:0]                         rows_das_o,
 `endif
   // Slave
   input  burst_req_t burst_req_i,
@@ -80,7 +81,7 @@ module idma_split_midend #(
   logic [AddrWidth-1:0] post_scramble_src;
   logic [AddrWidth-1:0] post_scramble_dst;
   logic [$clog2(NumTiles):0] tiles_das_src,   tiles_das_dst,   tiles_das_sel;
-  logic [$clog2(NumTiles):0] rows_das_src, rows_das_dst, rows_das_sel;
+  logic [RowsInterleavingWidth:0] rows_das_src, rows_das_dst, rows_das_sel;
 
   assign tiles_das_sel   = tiles_das_src   | tiles_das_dst;
   assign rows_das_sel = rows_das_src | rows_das_dst;
@@ -90,8 +91,10 @@ module idma_split_midend #(
     .AddrWidth        (AddrWidth       ),
     .NumTiles         (NumTiles        ),
     .NumBanksPerTile  (NumBanksPerTile ),
+    .RowsInterleavingWidth (RowsInterleavingWidth),
     .Bypass           (0               ),
     .NumDASPartitions (NumDASPartitions),
+    .DASStartAddr     (DASStartAddr    ),
     .TCDMSizePerBank  (TCDMSizePerBank )
   ) i_idma_address_scrambler_src (
     .address_i          (burst_req_i.src),
@@ -108,8 +111,10 @@ module idma_split_midend #(
     .AddrWidth        (AddrWidth       ),
     .NumTiles         (NumTiles        ),
     .NumBanksPerTile  (NumBanksPerTile ),
+    .RowsInterleavingWidth (RowsInterleavingWidth),
     .Bypass           (0               ),
     .NumDASPartitions (NumDASPartitions),
+    .DASStartAddr     (DASStartAddr    ),
     .TCDMSizePerBank  (TCDMSizePerBank )
   ) i_idma_address_scrambler_dst (
     .address_i          (burst_req_i.dst),
@@ -173,7 +178,7 @@ module idma_split_midend #(
   `FFARN(beat_cnt_q, beat_cnt_d, '0, clk_i, rst_ni)
 
   // log2(rows_das_sel): number of row-index bits in the active partition
-  logic [$clog2(NumTiles):0] log2_rows;
+  logic [$clog2(RowsInterleavingWidth+1)-1:0] log2_rows;
   // Bitmask to extract row index from the beat counter (lower log2_rows bits)
   logic [$clog2(NumTiles):0] row_idx_mask;
   // Current row index within the partition (0 .. rows_das-1)
@@ -182,7 +187,7 @@ module idma_split_midend #(
   logic [$clog2(NumTiles):0] col_idx;
 
   lzc #(
-    .WIDTH ($clog2(NumTiles)+1),
+    .WIDTH (RowsInterleavingWidth+1),
     .MODE  (1'b0              )
   ) i_log2_rows (
     .in_i    (rows_das_sel),

--- a/hardware/scripts/gen_trace.py
+++ b/hardware/scripts/gen_trace.py
@@ -74,23 +74,39 @@ MEM_REGIONS = {'Other': 0, 'Sequential': 1, 'Interleaved': 2}
 RAW_TYPES = ['lsu', 'acc']
 
 # ----------------- Architecture Info  -----------------
-NUM_CORES = int(os.environ.get('num_cores', 256))
-NUM_TILES = NUM_CORES / 4
-SEQ_MEM_SIZE = 4 * int(os.environ.get('seq_mem_size', 1024))
-TCDM_SIZE = 16 * 1024 * NUM_TILES
 
 
-def addr_to_meta(address):
+def env_int(name, default):
+    # Keep direct legacy invocations using lowercase variable names working.
+    return int(os.environ.get(name, os.environ.get(name.lower(), default)))
+
+
+NUM_CORES = env_int('NUM_CORES', 256)
+NUM_CORES_PER_TILE = env_int('NUM_CORES_PER_TILE', 4)
+BANKING_FACTOR = env_int('BANKING_FACTOR', 4)
+L1_BANK_SIZE = env_int('L1_BANK_SIZE', 1024)
+NUM_TILES = NUM_CORES // NUM_CORES_PER_TILE
+NUM_BANKS_PER_TILE = NUM_CORES_PER_TILE * BANKING_FACTOR
+INTERLEAVE_STRIDE = 4 * NUM_BANKS_PER_TILE
+SEQ_MEM_SIZE = NUM_CORES_PER_TILE * env_int('SEQ_MEM_SIZE', 1024)
+TCDM_SIZE = NUM_BANKS_PER_TILE * L1_BANK_SIZE * NUM_TILES
+
+
+def addr_to_meta(address, tcdm_address=None):
+    # The logical address selects the region; the observed TCDM address
+    # selects the actual destination tile when DAS remaps the request.
     region = MEM_REGIONS['Other']
     tile = -1
     if (address < SEQ_MEM_SIZE * NUM_TILES):
         # Local memory
         region = MEM_REGIONS['Sequential']
-        tile = address // SEQ_MEM_SIZE
+        tile = (address // SEQ_MEM_SIZE if tcdm_address is None else
+                (tcdm_address // INTERLEAVE_STRIDE) % NUM_TILES)
     elif (address < TCDM_SIZE):
         # Interleaved memory
         region = MEM_REGIONS['Interleaved']
-        tile = address // 64
+        tile = ((address if tcdm_address is None else tcdm_address) //
+                INTERLEAVE_STRIDE)
         tile = tile % NUM_TILES
     return region, tile
 
@@ -188,7 +204,8 @@ def annotate_snitch(
         # Load / Store
         if extras['is_load']:
             perf_metrics[-1]['snitch_loads'] += 1
-            gpr_wb_info[extras['rd']].appendleft((cycle, extras['alu_result']))
+            gpr_wb_info[extras['rd']].appendleft((
+                cycle, extras['alu_result'], extras.get('tcdm_addr')))
             ret.append('{:<3} <~~ {}[{}]'.format(
                 REG_ABI_NAMES_I[extras['rd']], LS_SIZES[extras['ls_size']],
                 int_lit(extras['alu_result'], force_hex=force_hex_addr)))
@@ -197,7 +214,8 @@ def annotate_snitch(
             ret.append('{} ~~> {}[{}]'.format(
                 int_lit(extras['gpr_rdata_1']), LS_SIZES[extras['ls_size']],
                 int_lit(extras['alu_result'], force_hex=force_hex_addr)))
-            region, tile = addr_to_meta(extras['alu_result'])
+            region, tile = addr_to_meta(
+                extras['alu_result'], extras.get('tcdm_addr'))
             perf_metrics[-1].setdefault('snitch_store_region',
                                         []).append(region)
             perf_metrics[-1].setdefault('snitch_store_tile',
@@ -215,8 +233,9 @@ def annotate_snitch(
     # stall and during other ops
     if extras['retire_load']:
         try:
-            start_time, address = gpr_wb_info[extras['lsu_rd']].pop()
-            region, tile = addr_to_meta(address)
+            start_time, address, tcdm_address = \
+                gpr_wb_info[extras['lsu_rd']].pop()
+            region, tile = addr_to_meta(address, tcdm_address)
             perf_metrics[-1].setdefault('snitch_load_latency',
                                         []).append(cycle - start_time)
             perf_metrics[-1].setdefault('snitch_load_region',
@@ -284,7 +303,7 @@ def annotate_snitch(
 
 def annotate_insn(
     line: str,
-    # One deque (FIFO) per GPR storing start cycles for each GPR WB
+    # One deque (FIFO) per GPR storing metadata for each pending load
     gpr_wb_info: dict,
     # A list performance metric dicts
     perf_metrics: list,
@@ -348,7 +367,7 @@ def safe_div(dividend, divisor):
 
 
 def eval_perf_metrics(perf_metrics: list, id: int):
-    tile_id = int(id // 4)
+    tile_id = int(id // NUM_CORES_PER_TILE)
     for seg in perf_metrics:
         end = seg['end']
         cycles = end - seg['start'] + 1

--- a/hardware/scripts/merge_tcdm_trace.py
+++ b/hardware/scripts/merge_tcdm_trace.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge a testbench TCDM address trace into a raw core trace."""
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+
+# Raw trace:
+#   <time> <cycle> <pc> <instruction> #; {
+#     'source': 0x00000000,
+#     'stall': 0x0,
+#     ...
+#     'is_load': 0x1,
+#     'is_store': 0x0,
+#     ...
+#   }
+# Accepted requests have 'stall': 0x0 and either 'is_load' or 'is_store'
+# set to 0x1. Other signal values are not used here.
+# Extra TCDM address trace, generated when address tracing is enabled:
+#   <cycle>,<tcdm_addr>  (no header row)
+# Accepted requests are joined on <cycle>, then 'tcdm_addr' is added to the
+# raw trace signal values.
+_CYCLE_RE = re.compile(r"^\s*\d+\s+(\d+)\s+")
+
+
+def _load_addresses(path):
+    addresses = {}
+    with path.open(newline="") as infile:
+        for line_no, row in enumerate(csv.reader(infile), 1):
+            if len(row) != 2:
+                raise ValueError(f"Malformed address trace {path}:{line_no}")
+            cycle, address = int(row[0], 0), int(row[1], 0)
+            # A core can accept at most one LSU request per cycle.
+            if cycle in addresses:
+                raise ValueError(f"Duplicate cycle in {path}:{line_no}")
+            addresses[cycle] = address
+    return addresses
+
+
+def _issue_cycle(line):
+    if ("'stall': 0x0" not in line or
+            ("'is_load': 0x1" not in line and
+             "'is_store': 0x1" not in line)):
+        return None
+    match = _CYCLE_RE.match(line)
+    return int(match.group(1)) if match else None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", type=argparse.FileType("r"))
+    parser.add_argument("addresses", type=Path)
+    args = parser.parse_args(argv)
+
+    if not args.addresses.is_file():
+        raise SystemExit(
+            f"Missing TCDM address trace: {args.addresses}")
+
+    addresses = _load_addresses(args.addresses)
+    # Check the core trace and TCDM address trace before writing output.
+    issue_cycles = {
+        cycle for line in args.trace
+        if (cycle := _issue_cycle(line)) is not None
+    }
+    missing = issue_cycles - addresses.keys()
+    unused = addresses.keys() - issue_cycles
+    if missing or unused:
+        raise SystemExit(
+            f"TCDM address mismatch for {args.addresses}: "
+            f"{len(missing)} missing, {len(unused)} unused\n"
+            "The core and TCDM address traces must come from the same "
+            "simulation.")
+
+    # Rewind after validation so an error cannot leave partial output.
+    args.trace.seek(0)
+    for line in args.trace:
+        cycle = _issue_cycle(line)
+        address = addresses.get(cycle) if cycle is not None else None
+        body = line.rstrip()
+        if (address is not None and "'tcdm_addr'" not in body and
+                "#;" in body and body.endswith("}")):
+            prefix = body[:-1].rstrip(", ")
+            line = f"{prefix}, 'tcdm_addr': 0x{address:08x}}}\n"
+        sys.stdout.write(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hardware/scripts/merge_trace_csvs.py
+++ b/hardware/scripts/merge_trace_csvs.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge per-trace performance CSV fragments into one results.csv.
+
+During `make trace`, every hart writes its own small CSV fragment so that
+parallel trace generation never appends to a shared file. This script merges
+the fragments into a single results.csv, sorted by core and section.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+# Performance rows contain list-valued fields that can exceed the CSV default.
+csv.field_size_limit(sys.maxsize)
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Merge per-trace performance CSV fragments '
+                    'into one results.csv.')
+    parser.add_argument(
+        '--folder',
+        required=True,
+        help='Directory containing per-trace CSV fragments.',
+    )
+    parser.add_argument(
+        '--csv',
+        required=True,
+        help='Merged CSV output path.',
+    )
+    parser.add_argument(
+        '--expected-count',
+        type=int,
+        help='Expected number of fragment CSV files. If set, refuse to '
+             'merge when the count differs.',
+    )
+    return parser.parse_args(argv)
+
+
+def load_fragment(fragment_path: Path) -> tuple[list[str], list[list[str]]]:
+    with fragment_path.open(newline='') as handle:
+        reader = csv.reader(handle)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return [], []
+        rows = [row for row in reader if any(value != '' for value in row)]
+    return header, rows
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    fragment_dir = Path(args.folder)
+    output_path = Path(args.csv)
+
+    fragment_paths = sorted(fragment_dir.glob('*.csv'))
+    if not fragment_paths:
+        sys.stderr.write(f'ERROR: no CSV fragments found in {fragment_dir}\n')
+        return 1
+    if args.expected_count is not None and len(
+            fragment_paths) != args.expected_count:
+        sys.stderr.write(
+            f'ERROR: expected {args.expected_count} CSV fragments in '
+            f'{fragment_dir}, but found {len(fragment_paths)}\n')
+        return 1
+
+    merged_header: list[str] | None = None
+    merged_rows: list[list[str]] = []
+    fragment_count = 0
+
+    for fragment_path in fragment_paths:
+        header, rows = load_fragment(fragment_path)
+        if not header:
+            continue
+        if merged_header is None:
+            merged_header = header
+        elif header != merged_header:
+            sys.stderr.write(
+                f'ERROR: header mismatch in {fragment_path}; expected '
+                f'exact match to first fragment\n')
+            return 1
+        fragment_count += 1
+        merged_rows.extend(rows)
+
+    if merged_header is None or not merged_rows:
+        sys.stderr.write(
+            f'ERROR: no performance rows found in {fragment_dir}\n')
+        return 1
+
+    try:
+        core_index, section_index = (
+            merged_header.index(column) for column in ('core', 'section'))
+        merged_rows.sort(
+            key=lambda row: (int(row[core_index]), int(row[section_index])))
+    except (IndexError, ValueError) as error:
+        sys.stderr.write(f'ERROR: invalid core or section column: {error}\n')
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open('w', newline='') as handle:
+        writer = csv.writer(handle)
+        writer.writerow(merged_header)
+        writer.writerows(merged_rows)
+
+    print(f'Merged {len(merged_rows)} rows from {fragment_count} '
+          f'fragment files into {output_path}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/hardware/scripts/trace_analysis/README.md
+++ b/hardware/scripts/trace_analysis/README.md
@@ -1,0 +1,190 @@
+# Benchmark Trace Analysis
+
+Two stages, and you can run them independently:
+
+```
+result_dir=<run> make benchmark  ->  <run>/{data,topology.env,...}
+result_dir=<run> make plots      ->  <run>/plots
+```
+
+Run both commands from `hardware/`. `make benchmark` builds and simulates an
+application, converts its traces, and saves the analysis inputs. `make plots`
+only reads the selected result directory, including its recorded topology.
+
+## Quick Start
+
+Use the [normal MemPool toolchain setup](../../../README.md#get-started). From
+the repository root, run:
+
+```bash
+python3 -m pip install -r python-requirements.txt
+cd hardware
+result_dir=results/example make benchmark
+result_dir=results/example make plots
+```
+
+The workflow defaults to `app=matmul_i32`, `config=mempool`, `das=1`,
+`back2local=0` (see the [configuration guide](../../../config/README.md#back2local)),
+and the QuestaSim target `simc`. Without `result_dir`, it uses:
+
+```
+results/<app>_<config>/<baseline|das>[_back2local]
+```
+
+This suffix is only a run label derived from `das` and `back2local`. Setting
+`variant` changes the directory name, not the hardware configuration.
+
+## Options
+
+Normal Make configuration variables, such as `config`, `das`, topology sizes,
+and application-specific build variables, configure the benchmark stage. These
+variables control the workflow itself:
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `app` | `matmul_i32` | Bare-metal application to build and simulate |
+| `python` | `python3` | Python interpreter used by the workflow |
+| `result_dir` | path above | Result directory written or read |
+| `benchmark_sim` | `simc` | Simulator target; use `simcvcs` for VCS |
+| `extract_jobs` | `16` | Parallel trace conversion and extraction jobs |
+| `force` | off | Set `force=1` to replace existing benchmark CSVs |
+| `plot_section` | `1` | [Benchmark section](#sections-and-addresses) selected by both plotters |
+| `plot_indiv_tiles` | `0` | Set to `1` to add every per-tile page |
+| `plot_window_cycles` | `64` | Time-series bin width in cycles |
+| `plot_comm` | `1` | Set to `0` to omit communication figures |
+| `plot_jobs` | `1` | Parallel workers for per-tile pages |
+
+Both scripts take `--help`. `plot_comm.py --figures ...` renders selected
+communication figure families.
+
+## Result Directory
+
+`make benchmark` produces:
+
+```
+<run>/
+  <app>, <app>.dump
+  results.csv, avg.txt
+  topology.env
+  transcript                 # when available
+  data/
+    comm_events_benchmark.csv
+    stall_timeseries_benchmark.csv
+```
+
+Raw trace intermediates are removed after extraction. The two files under
+`data/` and `topology.env` are the inputs to `make plots`. Performance summaries
+and the application binary are kept for reference.
+
+`make plots` adds:
+
+```
+<run>/plots/
+  overview/
+    overview_workload.png
+    group_ipc_breakdown.png
+    overview_temporal.png
+  communication/
+    traffic_matrix.png
+    traffic_matrix_groups.png
+    latency_timeseries.png
+    latency_tile_g<N>.png
+    latency_matrix.png
+    latency_excess_matrix.png
+  group<N>/
+    tile_detail_tile<N>.png
+    subgroup<N>/tile_detail_tile<N>.png
+```
+
+Tile-detail plots are generated only with `plot_indiv_tiles=1`. Topologies
+without subgroups place them directly under `group<N>`; other topologies use
+the intermediate `subgroup<N>` directory. Existing plots are overwritten, but
+files from figure families that are no longer selected are not removed.
+
+`make benchmark` refuses to replace either analysis CSV unless `force=1` is
+set. `make plots` requires the saved inputs but does not use the current RTL
+configuration. If `result_dir` is omitted, the current Make variables only
+select its default path.
+
+## Sections and Addresses
+
+The standard workflow extracts section 1, delimited by writes to the `trace`
+CSR. It therefore expects one `mempool_start_benchmark()` and
+`mempool_stop_benchmark()` bracket. Applications with another section layout
+must use `scripts/trace_analysis/extract/extract_benchmark_csvs.py` directly
+with `--section`.
+
+For `make benchmark`, a testbench observer records the physical address of
+every accepted Snitch LSU request after RTL scrambling. The address trace is
+joined to the core trace by cycle. Any mismatch aborts extraction. This makes
+the destination fields valid for runtime DAS configurations without modelling
+the scrambler in Python.
+
+The observer covers core LSU traffic in `simc` and `simcvcs`. DMA traffic and
+other memory masters are not part of these CSVs. A plain `make trace` uses the
+logical core-trace address. This is enough for stall analysis, but not for
+physical DAS locality. Because the observer is a compile-time testbench option,
+switching between `make benchmark` and a plain simulation in one build directory
+can rebuild the simulation model.
+
+## CSV Contract
+
+`stall_timeseries_benchmark.csv`:
+
+```
+core,group,tile,tile_in_group,core_in_tile,core_in_group,section,cycle,state,pc,insn,stall_interval_id,stall_interval_start,stall_interval_end,stall_interval_cycles,stall_interval_offset,stall_kind,stall_kind_exact,stall_tot,stall_ins,stall_raw,stall_raw_lsu,stall_raw_acc,stall_lsu,stall_acc,stall_wfi
+```
+
+`comm_events_benchmark.csv`:
+
+```
+section,cycle,core,group,subgroup,tile,tile_in_group,tile_in_subgroup,core_in_tile,core_in_group,event_type,request_id,pc,insn,origin_pc,origin_insn,rd,size_bytes,address,region,dest_tile,dest_group,dest_subgroup,is_local,is_same_group,is_same_subgroup,issue_cycle,return_cycle,latency
+```
+
+The stall CSV contains one `issue` or `stall` row per represented core cycle.
+Reported stall causes can overlap and need not add up to `stall_tot`.
+`stall_raw_lsu` and `stall_raw_acc` are inferred from register dependencies.
+Plots divide mixed-cause cycles between their reported causes. The
+`stall_interval_*` fields identify each reconstructed stall interval and the
+row's offset within it. For stall rows, `stall_kind_exact` is `1` when at most
+one cause was reported.
+
+The communication CSV contains `load_issue`, `store_issue`, and `load_return`
+rows. `request_id` joins a load return to its issue. Traffic figures count load
+and store issues, while latency figures use load returns. Requests outside the
+decoded TCDM regions have empty destination and locality fields. `region`
+classifies the logical address as `sequential`, `interleaved`, or `other`.
+
+`address` is the logical `alu_result` value inherited from the core trace. For
+post-increment operations this is the updated base address, not the address
+accessed. The `dest_*` and locality fields still use the physical TCDM address
+observed for the accepted request.
+
+## Topology Metadata
+
+Every result needs `topology.env` beside its `data` directory. The required
+keys are `NUM_CORES`, `NUM_GROUPS`, `NUM_CORES_PER_TILE`, `SEQ_MEM_SIZE`,
+`BANKING_FACTOR`, `L1_BANK_SIZE`, and `NUM_SUB_GROUPS_PER_GROUP`. `CONFIG` is
+informational. `REMOTE_GROUP_LATENCY_CYCLES` is optional for old runs and
+defaults to 7.
+
+Values must be positive and describe an evenly divisible core, tile, group,
+and subgroup hierarchy. `make benchmark` writes this file automatically. For
+data produced elsewhere, create it manually or pass `--topology-env` to the
+extractor.
+
+## Extending the Workflow
+
+Keep the result directory as the boundary between simulation, extraction, and
+plotting:
+
+- Make targets and recorded metadata live in `benchmark.mk`.
+- Topology validation and derived geometry live in `_workflow_metadata.py`.
+- Add trace events or CSV fields in `extract/extract_benchmark_csvs.py`.
+- Add stall figures in `plot/_stall_plots.py` and communication figures in
+  `plot/plot_comm.py`.
+- Keep plotters dependent on the saved CSVs and `topology.env`, not the current
+  build directory or Make configuration.
+
+Python names prefixed with an underscore are internal. The public interfaces
+are `make benchmark`, `make plots`, the two CSV schemas, and `topology.env`.

--- a/hardware/scripts/trace_analysis/_workflow_metadata.py
+++ b/hardware/scripts/trace_analysis/_workflow_metadata.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""topology.env is the single source of truth for the machine shape.
+
+`make benchmark` writes it into every result directory from the same
+make variables that configured the RTL. To analyze foreign data, write
+the file by hand: one KEY=value per line, all TOPOLOGY_KEYS required
+(see the README).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TOPOLOGY_KEYS = (
+    'NUM_CORES',
+    'NUM_GROUPS',
+    'NUM_CORES_PER_TILE',
+    'SEQ_MEM_SIZE',
+    'BANKING_FACTOR',
+    'L1_BANK_SIZE',
+    'NUM_SUB_GROUPS_PER_GROUP',
+)
+# Historical default from config.mk for older topology files.
+OPTIONAL_TOPOLOGY_DEFAULTS = {
+    'REMOTE_GROUP_LATENCY_CYCLES': 7,
+}
+
+
+def derive_topology(topology) -> dict:
+    """Return topology metadata with its common derived geometry."""
+    topology = dict(topology)
+    values = {key: int(topology[key]) for key in TOPOLOGY_KEYS}
+    values.update({
+        key: int(topology.get(key, default))
+        for key, default in OPTIONAL_TOPOLOGY_DEFAULTS.items()
+    })
+    invalid = [f'{key}={value}' for key, value in values.items()
+               if value <= 0]
+    if invalid:
+        raise ValueError(
+            f'Topology values must be positive: {", ".join(invalid)}')
+
+    n_cores = values['NUM_CORES']
+    n_groups = values['NUM_GROUPS']
+    cores_per_tile = values['NUM_CORES_PER_TILE']
+    n_subgroups = values['NUM_SUB_GROUPS_PER_GROUP']
+    if n_cores % cores_per_tile:
+        raise ValueError(
+            'NUM_CORES must be divisible by NUM_CORES_PER_TILE')
+    n_tiles = n_cores // cores_per_tile
+    if n_tiles % n_groups:
+        raise ValueError('The number of tiles must be divisible by NUM_GROUPS')
+    tiles_per_group = n_tiles // n_groups
+    if tiles_per_group % n_subgroups:
+        raise ValueError(
+            'The number of tiles per group must be divisible by '
+            'NUM_SUB_GROUPS_PER_GROUP')
+
+    # Keep topology.env keys and add lowercase derived values for consumers.
+    topology.update(values)
+    banks_per_tile = cores_per_tile * values['BANKING_FACTOR']
+
+    topology.update({
+        'n_cores': n_cores,
+        'n_groups': n_groups,
+        'cores_per_tile': cores_per_tile,
+        'cores_per_group': n_cores // n_groups,
+        'n_tiles': n_tiles,
+        'tiles_per_group': tiles_per_group,
+        'n_subgroups_per_group': n_subgroups,
+        'remote_group_latency_cycles':
+            values['REMOTE_GROUP_LATENCY_CYCLES'],
+        'tiles_per_subgroup': tiles_per_group // n_subgroups,
+        'banks_per_tile': banks_per_tile,
+        'seq_mem_size_per_tile': (
+            cores_per_tile * values['SEQ_MEM_SIZE']),
+        'interleave_stride': 4 * banks_per_tile,  # Four bytes per TCDM word.
+        'tcdm_size': (
+            banks_per_tile * values['L1_BANK_SIZE'] * n_tiles),
+    })
+    return topology
+
+
+def load_topology(path) -> dict:
+    """Read a topology.env file; every TOPOLOGY_KEYS entry is required."""
+    path = Path(path)
+    if not path.is_file():
+        raise ValueError(
+            f'Missing topology file: {path}\n'
+            'Every `make benchmark` run writes it; for foreign data '
+            'create it by hand (see the README).')
+    values = {}
+    for line in path.read_text().splitlines():
+        key, sep, value = line.strip().partition('=')
+        if sep and key and not key.startswith('#'):
+            values[key.strip()] = value.strip()
+    missing = [key for key in TOPOLOGY_KEYS if key not in values]
+    if missing:
+        raise ValueError(f'{path} is missing: {", ".join(missing)}')
+    topology = {key: int(values[key]) for key in TOPOLOGY_KEYS}
+    topology.update({
+        key: values.get(key, default)
+        for key, default in OPTIONAL_TOPOLOGY_DEFAULTS.items()
+    })
+    topology['config'] = values.get('CONFIG', '')
+    return derive_topology(topology)
+
+
+def describe(topology: dict) -> str:
+    config = topology.get('config')
+    parts = [f'config={config}'] if config else []
+    keys = (*TOPOLOGY_KEYS, *OPTIONAL_TOPOLOGY_DEFAULTS)
+    parts += [f'{key.lower()}={topology[key]}' for key in keys]
+    return ', '.join(parts)

--- a/hardware/scripts/trace_analysis/benchmark.mk
+++ b/hardware/scripts/trace_analysis/benchmark.mk
@@ -1,0 +1,93 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+# Two-stage benchmark workflow (see README.md in this directory):
+#   make benchmark    build `app`, simulate it, and extract benchmark CSVs
+#   make plots        render stall and communication figures from those CSVs
+
+# Defaults for the workflow goals only; inherited targets are unaffected.
+ifneq ($(filter build_app benchmark plots,$(MAKECMDGOALS)),)
+app        ?= matmul_i32
+variant    ?= $(if $(filter 1,$(das)),das,baseline)$(if $(filter 1,$(back2local)),_back2local)
+result_dir ?= $(resultpath)/$(app)_$(config)/$(variant)
+# Limit lookup to bare-metal apps. build_app creates the selected binary before
+# simulation, so parse-time validation is skipped.
+app_path   ?= $(abspath $(ROOT_DIR)/../software/bin/apps/baremetal)
+skip_app_validation := 1
+endif
+
+# Extraction defaults.
+benchmark_sim      ?= simc
+extract_jobs       ?= 16
+extract_dir        := $(ROOT_DIR)/scripts/trace_analysis/extract
+extract_args        = --benchmark-only -p --force -j $(extract_jobs)
+
+# Plot defaults.
+plot_section       ?= 1
+plot_indiv_tiles   ?= 0
+plot_window_cycles ?= 64
+plot_comm          ?= 1
+plot_jobs          ?= 1
+
+section_arg = $(if $(plot_section),--section $(plot_section))
+plot_args   = $(section_arg) --overview \
+              $(if $(filter 1,$(plot_indiv_tiles)),,--skip-tile-details) \
+              --window $(plot_window_cycles) -j $(plot_jobs)
+
+# Topology metadata for the analysis scripts.
+topology_env = CONFIG=$(config) \
+               NUM_CORES=$(num_cores) NUM_GROUPS=$(num_groups) \
+               NUM_CORES_PER_TILE=$(num_cores_per_tile) \
+               SEQ_MEM_SIZE=$(seq_mem_size) BANKING_FACTOR=$(banking_factor) \
+               L1_BANK_SIZE=$(l1_bank_size) \
+               NUM_SUB_GROUPS_PER_GROUP=$(num_sub_groups_per_group) \
+               REMOTE_GROUP_LATENCY_CYCLES=$(remote_group_latency_cycles)
+
+# Check elaboration defines on every invocation and update the stamp only when
+# they change, so Questa and VCS rebuild only when needed.
+vlog_defs_stamp := $(buildpath)/.vlog_defs
+$(vlog_defs_stamp): export _vlog_defs = $(vlog_defs)
+$(vlog_defs_stamp): FORCE | $(buildpath)
+	@printf '%s\n' "$$_vlog_defs" | cmp -s - $@ || \
+		printf '%s\n' "$$_vlog_defs" > $@
+$(buildpath)/compile.tcl: $(vlog_defs_stamp)
+$(buildpath)/compilevcs.sh: $(vlog_defs_stamp)
+
+.PHONY: FORCE build_app benchmark plots
+
+build_app:
+	$(MAKE) -B -C $(MEMPOOL_DIR)/software/apps/baremetal config="$(config)" "$(app)"
+
+benchmark:
+	@[ "$(force)" = "1" ] || \
+		{ [ ! -f "$(result_dir)/data/stall_timeseries_benchmark.csv" ] && \
+		  [ ! -f "$(result_dir)/data/comm_events_benchmark.csv" ]; } || \
+		{ echo "ERROR: $(result_dir) already has results (set force=1 to overwrite)" >&2; exit 1; }
+	$(MAKE) build_app
+	mkdir -p "$(result_dir)/data"
+	cp "$(preload)" "$(preload).dump" "$(result_dir)"
+	printf '%s\n' $(topology_env) > "$(result_dir)/topology.env"
+	$(MAKE) app="$(app)" app_path="$(app_path)" tcdm_addr_trace=1 $(benchmark_sim)
+# A fresh sub-make discovers the traces.
+# Clearing app skips another binary lookup.
+	result_dir="$(result_dir)" $(MAKE) -j $(extract_jobs) app= trace copy_traces=0 tcdm_addr_trace=1
+	$(python) $(extract_dir)/extract_benchmark_csvs.py $(extract_args) \
+		--folder "$(tracepath)" \
+		--comm-csv "$(result_dir)/data/comm_events_benchmark.csv" \
+		--stall-csv "$(result_dir)/data/stall_timeseries_benchmark.csv"
+	rm -f $(buildpath)/trace_hart_*.dasm $(buildpath)/trace_hart_*.trace \
+		$(buildpath)/tcdm_addr_hart_*.csv
+	rm -rf $(tracepath)
+	@printf '\nBenchmark results: %s\nPlot with:\n  make plots python="%s" result_dir="%s"\n' \
+		"$(result_dir)" "$(python)" "$(result_dir)"
+
+plots:
+	@[ -f "$(result_dir)/data/stall_timeseries_benchmark.csv" ] || \
+		{ echo "ERROR: missing $(result_dir)/data/stall_timeseries_benchmark.csv (run 'make benchmark' first)" >&2; exit 1; }
+	@[ "$(plot_comm)" != "1" ] || [ -f "$(result_dir)/data/comm_events_benchmark.csv" ] || \
+		{ echo "ERROR: missing $(result_dir)/data/comm_events_benchmark.csv (run 'make benchmark' first or pass plot_comm=0)" >&2; exit 1; }
+	$(python) $(ROOT_DIR)/scripts/trace_analysis/plot/plot_all_tiles.py "$(result_dir)" $(plot_args)
+	@[ "$(plot_comm)" != "1" ] || \
+		$(python) $(ROOT_DIR)/scripts/trace_analysis/plot/plot_comm.py "$(result_dir)" \
+			$(section_arg) --window $(plot_window_cycles)

--- a/hardware/scripts/trace_analysis/extract/extract_benchmark_csvs.py
+++ b/hardware/scripts/trace_analysis/extract/extract_benchmark_csvs.py
@@ -1,0 +1,811 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract both benchmark CSVs in one pass over the traces in a folder.
+
+Each trace is read once. Load/store issues and load returns (with
+destinations decoded from the MemPool address map) go to --comm-csv;
+per-cycle stall rows (expanded from the stall counters on each retired
+instruction) go to --stall-csv. Used by `make benchmark`.
+
+Input: the raw spike-dasm traces in build/traces/, whose `#; { ... }`
+annotation dicts carry the per-cycle core signals.
+
+Both output schemas are documented in the README (Data Formats).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import multiprocessing
+import re
+import sys
+import tempfile
+from collections import defaultdict, deque
+from pathlib import Path
+
+_root = str(Path(__file__).resolve().parent.parent)
+if _root not in sys.path:
+    sys.path.insert(0, _root)
+
+from _workflow_metadata import (  # noqa: E402
+    derive_topology, describe, load_topology)
+
+
+# ---------------------------------------------------------------------------
+# Trace Format, Output Schemas, and Topology
+# ---------------------------------------------------------------------------
+
+_TRACE_IN_REGEX = re.compile(
+    r"(\d+)\s+(\d+)\s+(0x[0-9A-Fa-fz]+)\s+([^#;]*)(\s*#;\s*(.*))?"
+)
+_TRACE_MARKER_REGEX = re.compile(r"^csrwi?\s+trace\s*,")
+_RAW_ANNOTATION_REGEX = re.compile(r"'[^']+'\s*:")
+
+_REG_ABI_NAMES_I = (
+    "zero", "ra", "sp", "gp", "tp",
+    "t0", "t1", "t2",
+    "s0", "s1",
+    *(f"a{i}" for i in range(8)),
+    *(f"s{i}" for i in range(2, 12)),
+    *(f"t{i}" for i in range(3, 7)),
+)
+_LS_SIZE_BYTES = {0: 1, 1: 2, 2: 4, 3: 8}
+_MEM_REGION_LABELS = {0: "other", 1: "sequential", 2: "interleaved"}
+_IGNORABLE_TRACE_PREFIXES = (
+    "## Performance metrics",
+    "Performance metrics for section ",
+    "Wrote performance metrics to ",
+    "Sanity check failed!",
+    "total_stalls do not add up.",
+)
+
+_COMM_KEYS = [
+    "section",
+    "cycle",
+    "core",
+    "group",
+    "subgroup",
+    "tile",
+    "tile_in_group",
+    "tile_in_subgroup",
+    "core_in_tile",
+    "core_in_group",
+    "event_type",
+    "request_id",
+    "pc",
+    "insn",
+    "origin_pc",
+    "origin_insn",
+    "rd",
+    "size_bytes",
+    "address",
+    "region",
+    "dest_tile",
+    "dest_group",
+    "dest_subgroup",
+    "is_local",
+    "is_same_group",
+    "is_same_subgroup",
+    "issue_cycle",
+    "return_cycle",
+    "latency",
+]
+
+_STALL_KEYS = [
+    "core", "group", "tile", "tile_in_group", "core_in_tile",
+    "core_in_group", "section", "cycle", "state", "pc", "insn",
+    "stall_interval_id", "stall_interval_start", "stall_interval_end",
+    "stall_interval_cycles", "stall_interval_offset", "stall_kind",
+    "stall_kind_exact", "stall_tot", "stall_ins", "stall_raw",
+    "stall_raw_lsu", "stall_raw_acc", "stall_lsu", "stall_acc",
+    "stall_wfi",
+]
+
+
+_TOPOLOGY_DEFAULTS = {
+    "NUM_CORES": 256, "NUM_GROUPS": 1, "NUM_CORES_PER_TILE": 4,
+    "BANKING_FACTOR": 4, "L1_BANK_SIZE": 1024,
+    "NUM_SUB_GROUPS_PER_GROUP": 1, "SEQ_MEM_SIZE": 512,
+}
+
+
+def configure(topology=None):
+    """Set the topology globals from a metadata dict (defaults otherwise)."""
+    global _NUM_CORES, _NUM_GROUPS, _NUM_CORES_PER_TILE, _CORES_PER_GROUP
+    global _SEQ_MEM_SIZE, _NUM_TILES, _TILES_PER_GROUP, _TILES_PER_SUBGROUP
+    global _INTERLEAVE_STRIDE, _TCDM_SIZE
+
+    values = derive_topology({**_TOPOLOGY_DEFAULTS, **(topology or {})})
+    _NUM_CORES = values["n_cores"]
+    _NUM_GROUPS = values["n_groups"]
+    _NUM_CORES_PER_TILE = values["cores_per_tile"]
+    _CORES_PER_GROUP = values["cores_per_group"]
+    _SEQ_MEM_SIZE = values["seq_mem_size_per_tile"]
+    _NUM_TILES = values["n_tiles"]
+    _TILES_PER_GROUP = values["tiles_per_group"]
+    _TILES_PER_SUBGROUP = values["tiles_per_subgroup"]
+    _INTERLEAVE_STRIDE = values["interleave_stride"]
+    _TCDM_SIZE = values["tcdm_size"]
+
+
+configure()
+
+
+# ---------------------------------------------------------------------------
+# Raw Trace Decoding and Address Mapping
+# ---------------------------------------------------------------------------
+
+def _read_annotations(dict_str: str) -> dict:
+    """Convert known hex values to integers and retain X-valued fields."""
+    annot = {
+        key: int(
+            val, 16) for key, val in re.findall(
+            r"'([^']+)'\s*:\s*(0x[0-9a-fA-F]+)", dict_str)}
+    annot.update({
+        key: val for key, val in re.findall(
+            r"'([^']+)'\s*:\s*(0x[0-9a-fA-FxX]+)",
+            re.sub(r"'([^']+)'\s*:\s*(0x[0-9a-fA-F]+)", "", dict_str),
+        )
+    })
+    return annot
+
+
+def _detect_marker(insn: str) -> bool:
+    """Match writes to the trace CSR that delimit benchmark sections."""
+    return _TRACE_MARKER_REGEX.match(insn) is not None
+
+
+def _is_ignorable_trace_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith(_IGNORABLE_TRACE_PREFIXES):
+        return True
+    key, sep, value = stripped.partition(" ")
+    if sep and value and key.replace("_", "").isalnum():
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+    return False
+
+
+def _format_address(address: int | None) -> str:
+    if address is None:
+        return ""
+    return hex(int(address))
+
+
+def _reg_name(index: int | None) -> str:
+    if index is None or index < 0 or index >= len(_REG_ABI_NAMES_I):
+        return ""
+    return _REG_ABI_NAMES_I[index]
+
+
+def _get_core_hierarchy(core_id: int) -> dict:
+    if core_id < 0:
+        return {
+            "group": -1,
+            "subgroup": -1,
+            "tile": -1,
+            "tile_in_group": -1,
+            "tile_in_subgroup": -1,
+            "core_in_tile": -1,
+            "core_in_group": -1,
+        }
+    tile_id = core_id // _NUM_CORES_PER_TILE
+    tile_in_group = tile_id % _TILES_PER_GROUP
+    return {
+        "group": tile_id // _TILES_PER_GROUP,
+        "subgroup": tile_in_group // _TILES_PER_SUBGROUP,
+        "tile": tile_id,
+        "tile_in_group": tile_in_group,
+        "tile_in_subgroup": tile_in_group % _TILES_PER_SUBGROUP,
+        "core_in_tile": core_id % _NUM_CORES_PER_TILE,
+        "core_in_group": core_id % _CORES_PER_GROUP,
+    }
+
+
+def _addr_to_meta(
+        address: int,
+        tcdm_address: int | None = None) -> tuple[str, int, int, int]:
+    # The logical address selects the memory region; the observed TCDM
+    # address selects the actual destination when DAS remaps the request.
+    region_code = 0
+    dest_tile = -1
+    if 0 <= address < _SEQ_MEM_SIZE * _NUM_TILES:
+        region_code = 1
+        if tcdm_address is None:
+            dest_tile = address // _SEQ_MEM_SIZE
+        else:
+            dest_tile = (tcdm_address // _INTERLEAVE_STRIDE) % _NUM_TILES
+    elif 0 <= address < _TCDM_SIZE:
+        region_code = 2
+        routed_address = address if tcdm_address is None else tcdm_address
+        dest_tile = (routed_address // _INTERLEAVE_STRIDE) % _NUM_TILES
+    if dest_tile < 0:
+        return _MEM_REGION_LABELS[region_code], -1, -1, -1
+    dest_group = dest_tile // _TILES_PER_GROUP
+    dest_tile_in_group = dest_tile % _TILES_PER_GROUP
+    dest_subgroup = dest_tile_in_group // _TILES_PER_SUBGROUP
+    return _MEM_REGION_LABELS[region_code], int(
+        dest_tile), int(dest_group), int(dest_subgroup)
+
+
+def _issue_event_type_dict(extras: dict) -> list[dict]:
+    events = []
+    tcdm_address = (int(extras["tcdm_addr"])
+                    if "tcdm_addr" in extras else None)
+    if not extras.get("stall") and int(extras.get("is_load", 0)):
+        ls_size = int(extras.get("ls_size", 0))
+        events.append({
+            "event_type": "load_issue",
+            "rd_index": int(extras.get("rd", 0)),
+            "size_bytes": _LS_SIZE_BYTES.get(ls_size, ""),
+            "address": int(extras.get("alu_result", 0)),
+            "tcdm_address": tcdm_address,
+        })
+    elif not extras.get("stall") and int(extras.get("is_store", 0)):
+        ls_size = int(extras.get("ls_size", 0))
+        events.append({
+            "event_type": "store_issue",
+            "rd_index": None,
+            "size_bytes": _LS_SIZE_BYTES.get(ls_size, ""),
+            "address": int(extras.get("alu_result", 0)),
+            "tcdm_address": tcdm_address,
+        })
+    if int(extras.get("retire_load", 0)):
+        events.append({
+            "event_type": "load_return",
+            "rd_index": int(extras.get("lsu_rd", 0)),
+            "size_bytes": "",
+            "address": None,
+            "tcdm_address": None,
+        })
+    return events
+
+
+def _parse_line_events(line: str, permissive: bool) -> dict | None:
+    line = line.rstrip("\n")
+    if _is_ignorable_trace_line(line):
+        return None
+    match = _TRACE_IN_REGEX.search(line)
+    if match is None:
+        if permissive:
+            return None
+        raise ValueError(f"Not a valid trace line:\n{line}")
+    _, cycle_str, pc_str, insn, _, extras_str = match.groups()
+    events = []
+    extras = None
+    if extras_str and _RAW_ANNOTATION_REGEX.search(extras_str):
+        extras = _read_annotations(extras_str)
+        for key in (
+            "stall",
+            "is_load",
+            "is_store",
+            "retire_load",
+            "rd",
+            "lsu_rd",
+            "alu_result",
+            "ls_size",
+            "stall_tot",
+            "stall_ins",
+            "stall_raw",
+            "stall_lsu",
+                "stall_acc"):
+            extras.setdefault(key, 0)
+        events = _issue_event_type_dict(extras)
+    insn = insn.strip()
+    return {
+        "cycle": int(cycle_str),
+        "pc": pc_str,
+        "insn": insn,
+        "events": events,
+        "extras": extras,
+        "marker": _detect_marker(insn),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Communication Row Construction
+# ---------------------------------------------------------------------------
+
+def _make_row(
+        section: int,
+        cycle: int,
+        core_id: int,
+        hierarchy: dict,
+        *,
+        event_type: str,
+        request_id: int | str,
+        pc: str,
+        insn: str,
+        origin_pc: str,
+        origin_insn: str,
+        rd_index: int | None,
+        size_bytes,
+        address: int | None,
+        tcdm_address: int | None,
+        issue_cycle,
+        return_cycle,
+        latency):
+    region, dest_tile, dest_group, dest_subgroup = _addr_to_meta(
+        address, tcdm_address
+    ) if address is not None else ("", -1, -1, -1)
+    is_local = ""
+    is_same_group = ""
+    is_same_subgroup = ""
+    if dest_tile >= 0:
+        is_local = int(dest_tile == hierarchy["tile"])
+        is_same_group = int(dest_group == hierarchy["group"])
+        is_same_subgroup = int(
+            is_same_group and dest_subgroup == hierarchy["subgroup"])
+    return {
+        "section": section,
+        "cycle": cycle,
+        "core": core_id,
+        "group": hierarchy["group"],
+        "subgroup": hierarchy["subgroup"],
+        "tile": hierarchy["tile"],
+        "tile_in_group": hierarchy["tile_in_group"],
+        "tile_in_subgroup": hierarchy["tile_in_subgroup"],
+        "core_in_tile": hierarchy["core_in_tile"],
+        "core_in_group": hierarchy["core_in_group"],
+        "event_type": event_type,
+        "request_id": request_id,
+        "pc": pc,
+        "insn": insn,
+        "origin_pc": origin_pc,
+        "origin_insn": origin_insn,
+        "rd": _reg_name(rd_index),
+        "size_bytes": size_bytes,
+        "address": _format_address(address),
+        "region": region,
+        "dest_tile": dest_tile if dest_tile >= 0 else "",
+        "dest_group": dest_group if dest_group >= 0 else "",
+        "dest_subgroup": dest_subgroup if dest_subgroup >= 0 else "",
+        "is_local": is_local,
+        "is_same_group": is_same_group,
+        "is_same_subgroup": is_same_subgroup,
+        "issue_cycle": issue_cycle,
+        "return_cycle": return_cycle,
+        "latency": latency,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stall Classification and Metadata
+# ---------------------------------------------------------------------------
+
+def _raw_stall_sources(extras: dict | None,
+                       retired_regs: dict[str, int]) -> set[str]:
+    if extras is None or extras.get("stall"):
+        return set()
+    operands = {int(extras.get(name, 0)) for name in ("rs1", "rs2", "rd")}
+    return {
+        source for source, register in retired_regs.items()
+        if register > 0 and register in operands
+    }
+
+
+def _stall_info_from_extras(extras: dict, cycle: int,
+                            prev_wfi_time: int,
+                            raw_sources: set[str]) -> dict:
+    stall_tot = int(extras["stall_tot"])
+    stall_raw = int(extras["stall_raw"])
+    return {
+        "stall_tot": stall_tot,
+        "stall_ins": int(extras["stall_ins"]),
+        "stall_raw": stall_raw,
+        "stall_raw_lsu": stall_raw if "lsu" in raw_sources else 0,
+        "stall_raw_acc": stall_raw if "acc" in raw_sources else 0,
+        "stall_lsu": int(extras["stall_lsu"]),
+        "stall_acc": int(extras["stall_acc"]),
+        "stall_wfi": cycle - prev_wfi_time - 1
+        if prev_wfi_time != 0 and stall_tot > 0 else 0,
+    }
+
+
+def _classify_stall(stall_info: dict) -> tuple[str, int]:
+    categories = []
+    if stall_info["stall_ins"] > 0:
+        categories.append("ins")
+    if stall_info["stall_raw"] > 0:
+        categories.append("raw")
+    if stall_info["stall_lsu"] > 0:
+        categories.append("lsu")
+    if stall_info["stall_acc"] > 0:
+        categories.append("acc")
+    if stall_info["stall_wfi"] > 0:
+        categories.append("wfi")
+    if not categories:
+        return "none", 1
+    return "+".join(categories), int(len(categories) <= 1)
+
+
+def _add_stall_metadata(row: dict, core_id: int, hierarchy: dict,
+                        section: int):
+    row["core"] = core_id
+    row["group"] = hierarchy["group"]
+    row["tile"] = hierarchy["tile"]
+    row["tile_in_group"] = hierarchy["tile_in_group"]
+    row["core_in_tile"] = hierarchy["core_in_tile"]
+    row["core_in_group"] = hierarchy["core_in_group"]
+    row["section"] = section
+
+
+# ---------------------------------------------------------------------------
+# Per-Trace Extraction
+# ---------------------------------------------------------------------------
+
+def _extract_rows(infile, core_id: int, selected_sections: set,
+                  permissive: bool):
+    """One pass over a raw trace: communication rows and stall rows."""
+    hierarchy = _get_core_hierarchy(core_id)
+    pending_loads = defaultdict(deque)
+    next_request_id = 0
+    section = 0
+    prev_wfi_time = 0
+    retired_regs = {"lsu": -1, "acc": -1}
+    stall_interval_id = 0
+    comm_rows = []
+    stall_rows = []
+
+    def _selected():
+        return not selected_sections or section in selected_sections
+
+    for line in infile:
+        parsed = _parse_line_events(line, permissive)
+        if parsed is None:
+            continue
+        extras = parsed["extras"]
+        raw_sources = _raw_stall_sources(extras, retired_regs)
+
+        # Emit issues immediately and keep load metadata until its return.
+        for event in parsed["events"]:
+            if event["event_type"] == "load_issue":
+                request_id = next_request_id
+                next_request_id += 1
+                pending = {
+                    "request_id": request_id,
+                    "issue_cycle": parsed["cycle"],
+                    "pc": parsed["pc"],
+                    "insn": parsed["insn"],
+                    "rd_index": event["rd_index"],
+                    "size_bytes": event["size_bytes"],
+                    "address": event["address"],
+                    "tcdm_address": event["tcdm_address"],
+                }
+                if event["rd_index"] is not None:
+                    pending_loads[event["rd_index"]].appendleft(pending)
+                if _selected():
+                    comm_rows.append(_make_row(
+                        section,
+                        parsed["cycle"],
+                        core_id,
+                        hierarchy,
+                        event_type="load_issue",
+                        request_id=request_id,
+                        pc=parsed["pc"],
+                        insn=parsed["insn"],
+                        origin_pc=parsed["pc"],
+                        origin_insn=parsed["insn"],
+                        rd_index=event["rd_index"],
+                        size_bytes=event["size_bytes"],
+                        address=event["address"],
+                        tcdm_address=event["tcdm_address"],
+                        issue_cycle=parsed["cycle"],
+                        return_cycle="",
+                        latency="",
+                    ))
+
+            elif event["event_type"] == "store_issue":
+                if _selected():
+                    comm_rows.append(_make_row(
+                        section,
+                        parsed["cycle"],
+                        core_id,
+                        hierarchy,
+                        event_type="store_issue",
+                        request_id="",
+                        pc=parsed["pc"],
+                        insn=parsed["insn"],
+                        origin_pc=parsed["pc"],
+                        origin_insn=parsed["insn"],
+                        rd_index=None,
+                        size_bytes=event["size_bytes"],
+                        address=event["address"],
+                        tcdm_address=event["tcdm_address"],
+                        issue_cycle=parsed["cycle"],
+                        return_cycle="",
+                        latency="",
+                    ))
+
+            elif event["event_type"] == "load_return":
+                try:
+                    pending = pending_loads[event["rd_index"]].pop()
+                except IndexError:
+                    msg = (
+                        f"WARNING: In cycle {parsed['cycle']}, LSU return "
+                        f"to {_reg_name(event['rd_index'])} "
+                        f"had no matching in-flight load in {infile.name}.")
+                    if permissive:
+                        print(msg, file=sys.stderr)
+                        continue
+                    raise SystemExit(msg)
+                if _selected():
+                    comm_rows.append(_make_row(
+                        section,
+                        parsed["cycle"],
+                        core_id,
+                        hierarchy,
+                        event_type="load_return",
+                        request_id=pending["request_id"],
+                        pc=parsed["pc"],
+                        insn=parsed["insn"],
+                        origin_pc=pending["pc"],
+                        origin_insn=pending["insn"],
+                        rd_index=event["rd_index"],
+                        size_bytes=pending["size_bytes"],
+                        address=pending["address"],
+                        tcdm_address=pending["tcdm_address"],
+                        issue_cycle=pending["issue_cycle"],
+                        return_cycle=parsed["cycle"],
+                        latency=parsed["cycle"] - pending["issue_cycle"],
+                    ))
+
+        # A retired instruction reports counters for the preceding stall
+        # interval. Expand them into the per-cycle rows used by the plots.
+        if extras is not None and not extras.get("stall"):
+            cycle = parsed["cycle"]
+            stall_info = _stall_info_from_extras(extras, cycle,
+                                                 prev_wfi_time, raw_sources)
+            if _selected():
+                if stall_info["stall_tot"] > 0:
+                    interval_start = cycle - stall_info["stall_tot"]
+                    stall_kind, stall_kind_exact = _classify_stall(
+                        stall_info)
+                    for offset, stall_cycle in enumerate(
+                            range(interval_start, cycle)):
+                        row = {
+                            "cycle": stall_cycle,
+                            "state": "stall",
+                            "pc": "",
+                            "insn": "",
+                            "stall_interval_id": stall_interval_id,
+                            "stall_interval_start": interval_start,
+                            "stall_interval_end": cycle - 1,
+                            "stall_interval_cycles":
+                                stall_info["stall_tot"],
+                            "stall_interval_offset": offset,
+                            "stall_kind": stall_kind,
+                            "stall_kind_exact": stall_kind_exact,
+                        }
+                        row.update(stall_info)
+                        _add_stall_metadata(row, core_id, hierarchy,
+                                            section)
+                        stall_rows.append(row)
+                    stall_interval_id += 1
+                if parsed["insn"]:
+                    row = {
+                        "cycle": cycle,
+                        "state": "issue",
+                        "pc": parsed["pc"],
+                        "insn": parsed["insn"],
+                        "stall_interval_id": "",
+                        "stall_interval_start": "",
+                        "stall_interval_end": "",
+                        "stall_interval_cycles": 0,
+                        "stall_interval_offset": "",
+                        "stall_kind": "none",
+                        "stall_kind_exact": 1,
+                        "stall_tot": 0,
+                        "stall_ins": 0,
+                        "stall_raw": 0,
+                        "stall_raw_lsu": 0,
+                        "stall_raw_acc": 0,
+                        "stall_lsu": 0,
+                        "stall_acc": 0,
+                        "stall_wfi": 0,
+                    }
+                    _add_stall_metadata(row, core_id, hierarchy, section)
+                    stall_rows.append(row)
+            prev_wfi_time = cycle if parsed["insn"] == "wfi" else 0
+
+        # Retiring producers identify the source of later RAW stalls.
+        if extras is not None:
+            if int(extras.get("retire_load", 0)):
+                retired_regs["lsu"] = int(extras.get("lsu_rd", 0))
+            if (int(extras.get("retire_acc", 0)) and
+                    int(extras.get("acc_pid", 0)) != 0):
+                retired_regs["acc"] = int(extras["acc_pid"])
+            if not extras.get("stall"):
+                retired_regs = {"lsu": -1, "acc": -1}
+
+        # Trace markers delimit the application-defined benchmark sections.
+        if parsed["marker"]:
+            section += 1
+
+    return comm_rows, stall_rows
+
+
+# ---------------------------------------------------------------------------
+# CSV Output and Parallel Batch Processing
+# ---------------------------------------------------------------------------
+
+def _write_rows(rows: list[dict], filename: str, keys: list[str]):
+    with Path(filename).open("w", newline="") as out:
+        writer = csv.DictWriter(out, keys)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _core_id_from_name(filename):
+    match = re.search(r"(0x[0-9a-fA-F]+)", filename)
+    if match:
+        return int(match.group(1), 16)
+    match = re.search(r"([\d]+)", filename)
+    if match:
+        return int(match.group(1))
+    return -1
+
+
+def process_file(trace_path, csv_paths, *, sections=(), permissive=False):
+    """Extract one trace and write its rows to the two part CSVs."""
+    comm_csv, stall_csv = csv_paths
+    core_id = _core_id_from_name(Path(trace_path).name)
+    with Path(trace_path).open() as infile:
+        comm_rows, stall_rows = _extract_rows(
+            infile, core_id, set(sections), permissive)
+    _write_rows(comm_rows, comm_csv, _COMM_KEYS)
+    _write_rows(stall_rows, stall_csv, _STALL_KEYS)
+    return len(comm_rows) + len(stall_rows)
+
+
+_worker_sections = ()
+_worker_permissive = False
+
+
+def _init_worker(topology, sections, permissive):
+    global _worker_sections, _worker_permissive
+    configure(topology)
+    _worker_sections = sections
+    _worker_permissive = permissive
+
+
+def _process_trace(item):
+    trace_path, csv_paths = item
+    return process_file(
+        trace_path, csv_paths,
+        sections=_worker_sections, permissive=_worker_permissive)
+
+
+def _combine_parts(items, output_paths):
+    """Combine per-trace CSV parts in trace order with one header."""
+    for output_index, output_path in enumerate(output_paths):
+        with output_path.open("w", newline="") as output:
+            header_written = False
+            for _, part_paths in items:
+                part_path = part_paths[output_index]
+                if not part_path.exists():
+                    continue
+                with part_path.open() as part:
+                    for line_number, line in enumerate(part):
+                        if line_number:
+                            output.write(line)
+                        elif not header_written:
+                            output.write(line)
+                            header_written = True
+
+
+def _run_batch(args, parser):
+    folder = Path(args.folder)
+    if not folder.is_dir():
+        parser.error(f"--folder is not a directory: {folder}")
+
+    output_paths = [Path(args.comm_csv), Path(args.stall_csv)]
+    topology_path = (Path(args.topology_env) if args.topology_env
+                     else output_paths[0].parent.parent / "topology.env")
+    try:
+        topology = load_topology(topology_path)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    trace_files = sorted(
+        path for path in folder.glob("trace_hart_*")
+        if path.is_file() and path.suffix != ".dasm")
+    if not trace_files:
+        parser.error(f"No trace_hart_* files found in {folder}")
+    if len(trace_files) != topology["NUM_CORES"]:
+        print(f"Warning: found {len(trace_files)} traces, but topology "
+              f"expects {topology['NUM_CORES']} cores.", file=sys.stderr)
+
+    for output_path in output_paths:
+        if output_path.exists():
+            if not args.force:
+                parser.error(
+                    f"Output CSV already exists: {output_path}\n"
+                    "       Use --force to overwrite.")
+            output_path.unlink()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    sections = set(args.section or [])
+
+    print(f"Topology: {describe(topology)}", file=sys.stderr)
+    jobs = min(args.jobs, len(trace_files))
+    print(f"Extracting {len(trace_files)} traces with {jobs} workers ...",
+          file=sys.stderr)
+
+    with tempfile.TemporaryDirectory(prefix="benchmark_par_") as temp_dir:
+        temp_dir = Path(temp_dir)
+        items = [
+            (trace_path, (
+                temp_dir / f"comm_{index:04d}.csv",
+                temp_dir / f"stall_{index:04d}.csv"))
+            for index, trace_path in enumerate(trace_files)
+        ]
+        done = 0
+        with multiprocessing.Pool(
+                jobs, initializer=_init_worker,
+                initargs=(topology, sections, args.permissive)) as pool:
+            for _ in pool.imap_unordered(_process_trace, items):
+                done += 1
+                if done % 64 == 0 or done == len(trace_files):
+                    print(f"Processed {done}/{len(trace_files)} traces",
+                          file=sys.stderr)
+        _combine_parts(items, output_paths)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Extract the communication-event and stall "
+                    "time-series CSVs from all traces in a folder.")
+    parser.add_argument(
+        "--folder", required=True,
+        help="Folder containing trace_hart_* files")
+    parser.add_argument(
+        "--comm-csv", required=True,
+        help="Combined communication-events CSV output path")
+    parser.add_argument(
+        "--stall-csv", required=True,
+        help="Combined stall time-series CSV output path")
+    section = parser.add_mutually_exclusive_group()
+    section.add_argument(
+        "--section", type=int, action="append",
+        help="Emit rows only for the specified section; may be repeated")
+    section.add_argument(
+        "--benchmark-only", action="store_const", const=[1], dest="section",
+        help="Shortcut for --section 1 for apps with a single "
+             "benchmark bracket")
+    parser.add_argument(
+        "-p", "--permissive", action="store_true",
+        help="Ignore malformed non-trace lines when possible")
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite existing CSV output (default: refuse)")
+    parser.add_argument(
+        "--topology-env",
+        help="Path to topology.env (default: next to the output data dir)")
+    parser.add_argument(
+        "-j", "--jobs", type=int, default=16,
+        help="Number of parallel extraction workers (default: 16)")
+    args = parser.parse_args(argv)
+
+    _run_batch(args, parser)
+    print(f"Wrote communication events to {args.comm_csv}")
+    print(f"Wrote stall time-series to {args.stall_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hardware/scripts/trace_analysis/plot/_stall_plots.py
+++ b/hardware/scripts/trace_analysis/plot/_stall_plots.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Data loading, aggregation, and rendering for the stall plots."""
+
+import csv
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.lines import Line2D
+from matplotlib.patches import Patch
+from matplotlib.ticker import MaxNLocator
+
+
+# ---------------------------------------------------------------------------
+# Data Loading and Labels
+# ---------------------------------------------------------------------------
+
+STALL_CATEGORIES = ["ins", "raw", "lsu", "acc", "wfi", "other"]
+STALL_COLORS = {
+    "issue": "#78C679", "stall": "#D9D9D9",
+    "ins": "#4C78A8", "raw": "#F58518", "lsu": "#17BECF",
+    "acc": "#E45756", "wfi": "#B279A2", "other": "#9D755D",
+}
+STALL_LABELS = {
+    "issue": "Issuing", "stall": "Stalled",
+    "ins": "Instruction fetch", "raw": "RAW", "lsu": "LSU",
+    "acc": "Accelerator", "wfi": "WFI", "other": "Other / mixed",
+}
+
+
+def stall_label(category):
+    return STALL_LABELS.get(category, category)
+
+
+def _int(value):
+    return None if value is None or value == "" else int(value)
+
+
+def load_rows(csv_path):
+    rows = []
+    with Path(csv_path).open(newline="") as csv_file:
+        for row in csv.DictReader(csv_file):
+            rows.append({
+                "core": _int(row.get("core")),
+                "group": _int(row.get("group")),
+                "tile": _int(row.get("tile")),
+                "section": _int(row.get("section")),
+                "cycle": _int(row.get("cycle")),
+                "state": (row.get("state") or "").strip(),
+                "stall_kind": (row.get("stall_kind") or "").strip(),
+            })
+    return rows
+
+
+def filter_rows(rows, *, section=None, group=None, tile=None, core=None):
+    """Filter rows by optional sets of section/group/tile/core IDs."""
+    filters = {}
+    if section:
+        filters["section"] = set(section)
+    if group:
+        filters["group"] = set(group)
+    if tile:
+        filters["tile"] = set(tile)
+    if core:
+        filters["core"] = set(core)
+    if not filters:
+        return rows
+    return [row for row in rows
+            if all(row[name] in values for name, values in filters.items())]
+
+
+def split_stall_kind(kind):
+    if not kind or kind == "none":
+        return ["other"]
+    categories = [
+        part.strip() if part.strip() in STALL_CATEGORIES else "other"
+        for part in kind.split("+") if part.strip()
+    ]
+    return categories or ["other"]
+
+
+# ---------------------------------------------------------------------------
+# Shared Plot Helpers
+# ---------------------------------------------------------------------------
+
+def set_cycle_ticks(ax, positions, labels=None, max_ticks=25):
+    """Place x ticks at nice round cycle values."""
+    if len(positions) <= 1:
+        return
+    labels = positions if labels is None else labels
+    low, high = float(labels[0]), float(labels[-1])
+    span = high - low
+    if span <= 0:
+        return
+
+    raw_step = span / max_ticks
+    magnitude = 10 ** int(np.floor(np.log10(max(raw_step, 1))))
+    for multiplier in (1, 2, 5, 10, 20, 50, 100):
+        step = magnitude * multiplier
+        if span / step <= max_ticks:
+            break
+
+    first = int(np.ceil(low / step)) * step
+    nice_values = np.unique(np.concatenate((
+        [low], np.arange(first, high + 1, step), [high])))
+    label_values = np.array(labels, dtype=float)
+    tick_positions = []
+    tick_labels = []
+    for value in nice_values:
+        index = int(np.argmin(np.abs(label_values - value)))
+        tick_positions.append(positions[index])
+        tick_labels.append(str(int(label_values[index])))
+
+    min_gap = step * 0.45
+    filtered_positions = [tick_positions[0]]
+    filtered_labels = [tick_labels[0]]
+    for position, label in zip(tick_positions[1:], tick_labels[1:]):
+        if abs(int(label) - int(filtered_labels[-1])) >= min_gap:
+            filtered_positions.append(position)
+            filtered_labels.append(label)
+    ax.set_xticks(filtered_positions)
+    ax.set_xticklabels(filtered_labels)
+
+
+def plot_categories_current(
+        ax, cycles, category_values, present, title,
+        ylabel="Stalled cores"):
+    """Plot active stall categories as a stacked area."""
+    arrays = [category_values[category] for category in present]
+    ax.stackplot(
+        cycles,
+        arrays,
+        labels=[stall_label(category) for category in present],
+        colors=[STALL_COLORS[category] for category in present],
+        alpha=0.85,
+        step="post")
+    total = np.sum(np.vstack(arrays), axis=0) if arrays else np.zeros_like(
+        cycles)
+    maximum = float(np.max(total)) if len(total) else 0
+    ax.set_xlim(cycles[0], cycles[-1])
+    ax.set_ylim(0, max(1.0, maximum * 1.08))
+    ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    ax.set_title(title)
+    ax.set_ylabel(ylabel)
+    ax.grid(True, axis="y", alpha=0.25)
+    ax.legend(loc="upper left", frameon=True, fancybox=True,
+              edgecolor="#CCCCCC", facecolor="white", framealpha=0.68,
+              handleheight=1.1, handlelength=2.5)
+
+
+def plot_categories_cumulative(
+        ax, cycles, category_values, present, title):
+    """Plot active stall categories as cumulative lines."""
+    legend_handles = []
+    for category in present:
+        values = category_values[category]
+        ax.plot(cycles, values, color=STALL_COLORS[category],
+                lw=2.0, label=stall_label(category))
+        rising = np.diff(values, prepend=values[0]) > 0
+        ax.fill_between(cycles, 0, values, where=rising,
+                        color=STALL_COLORS[category], alpha=0.22)
+        legend_handles.append(Line2D(
+            [0], [0], color=STALL_COLORS[category], linewidth=4.0,
+            label=stall_label(category)))
+    maximum = max((float(np.max(category_values[category]))
+                   for category in present), default=0)
+    ax.set_xlim(cycles[0], cycles[-1])
+    ax.set_ylim(0, max(1.0, maximum * 1.05))
+    ax.set_title(title)
+    ax.set_ylabel("Accumulated core-cycles")
+    ax.grid(True, axis="y", alpha=0.25)
+    ax.legend(handles=legend_handles, loc="upper left", frameon=True,
+              fancybox=True, edgecolor="#CCCCCC", facecolor="white",
+              framealpha=0.9, handleheight=1.1, handlelength=3.0)
+
+
+# ---------------------------------------------------------------------------
+# Overview Time-Series Aggregation
+# ---------------------------------------------------------------------------
+
+def aggregate_rows(rows, window, context_field="tile"):
+    """Bin cluster issue and stall activity for the workload overview."""
+    min_cycle = min(r["cycle"] for r in rows)
+    max_cycle = max(r["cycle"] for r in rows)
+    nw = (max_cycle - min_cycle) // window + 1
+
+    issue = np.zeros(nw)
+    stall = np.zeros(nw)
+    mix = {c: np.zeros(nw) for c in STALL_CATEGORIES}
+    ctxs = {}
+
+    for r in rows:
+        wi = (r["cycle"] - min_cycle) // window
+        cv = r[context_field]
+        if cv not in ctxs:
+            ctxs[cv] = {
+                "issue": np.zeros(nw), "stall": np.zeros(nw),
+                "mix": {c: np.zeros(nw) for c in STALL_CATEGORIES},
+            }
+        if r["state"] == "issue":
+            issue[wi] += 1
+            ctxs[cv]["issue"][wi] += 1
+        else:
+            stall[wi] += 1
+            ctxs[cv]["stall"][wi] += 1
+            cats = split_stall_kind(r["stall_kind"])
+            w = 1.0 / len(cats)
+            for c in cats:
+                mix[c][wi] += w
+                ctxs[cv]["mix"][c][wi] += w
+
+    x_centers = np.array(
+        [min_cycle + i * window + window / 2.0 for i in range(nw)])
+    wf = float(window)
+    cvs = sorted(ctxs)
+    ctx_issue = np.array([ctxs[v]["issue"] / wf for v in cvs])
+    ctx_stall = np.array([ctxs[v]["stall"] / wf for v in cvs])
+
+    return {
+        "window": window, "min_cycle": min_cycle, "max_cycle": max_cycle,
+        "num_windows": nw, "x_centers": x_centers,
+        "overall": {
+            "issue_count": issue / wf,
+            "stall_count": stall / wf,
+            "stall_reason_count": {c: v / wf for c, v in mix.items()},
+        },
+        "context_values": cvs,
+        "context_issue_count": ctx_issue,
+        "context_stall_count": ctx_stall,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tile-Detail Aggregation
+# ---------------------------------------------------------------------------
+
+def build_tile_series(rows, tile_id):
+    """Build per-cycle and cumulative data for one tile-detail figure."""
+    tile_rows = [r for r in rows if r["tile"] == tile_id]
+    if not tile_rows:
+        raise ValueError(f"No rows for tile {tile_id}")
+
+    cycles = np.array(sorted({r["cycle"] for r in tile_rows}), dtype=int)
+    c2i = {int(c): i for i, c in enumerate(cycles)}
+    n = len(cycles)
+    issue_cur = np.zeros(n)
+    stall_cur = np.zeros(n)
+    cat_cur = {c: np.zeros(n) for c in STALL_CATEGORIES}
+
+    cores = sorted({r["core"] for r in tile_rows})
+    core2i = {cid: i for i, cid in enumerate(cores)}
+    per_core_state = np.zeros((len(cores), n))
+
+    cat_index = {c: i for i, c in enumerate(
+        STALL_CATEGORIES)}  # ins=0..other=5
+    for r in tile_rows:
+        ci = c2i[r["cycle"]]
+        if r["state"] == "issue":
+            issue_cur[ci] += 1
+            per_core_state[core2i[r["core"]], ci] = 1.0
+        else:
+            stall_cur[ci] += 1
+            cats_hit = split_stall_kind(r["stall_kind"])
+            w = 1.0 / len(cats_hit)
+            for cat in cats_hit:
+                cat_cur[cat][ci] += w
+            # Combined stalls use the first category in the heatmap (2–7).
+            per_core_state[core2i[r["core"]], ci] = (
+                2.0 + cat_index[cats_hit[0]])
+
+    present = [c for c in STALL_CATEGORIES if np.any(cat_cur[c] > 0)]
+    return {
+        "tile_id": tile_id,
+        "cores": cores,
+        "per_core_state": per_core_state,
+        "cycles": cycles,
+        "issue_current": issue_cur,
+        "stall_current": stall_cur,
+        "issue_cumulative": np.cumsum(issue_cur),
+        "stall_cumulative": np.cumsum(stall_cur),
+        "category_current": cat_cur,
+        "category_cumulative": {
+            c: np.cumsum(v) for c,
+            v in cat_cur.items()},
+        "present_categories": present,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Overview Figures
+# ---------------------------------------------------------------------------
+
+def _agg_ticks(ax, agg, max_ticks=12):
+    set_cycle_ticks(
+        ax,
+        np.arange(
+            agg["num_windows"]),
+        agg["x_centers"],
+        max_ticks)
+
+
+def write_overview_page(path, agg, filter_desc, window):
+    """Plot progress, stall composition, and per-tile stall fraction."""
+    fig = plt.figure(figsize=(16, 12), constrained_layout=True)
+    gs = fig.add_gridspec(2, 2, height_ratios=[1, 1.3])
+    ax_prog = fig.add_subplot(gs[0, 0])
+    ax_mix = fig.add_subplot(gs[0, 1])
+    ax_hm = fig.add_subplot(gs[1, :])
+
+    # 1 — progress
+    x = np.arange(agg["num_windows"])
+    ic = agg["overall"]["issue_count"]
+    sc = agg["overall"]["stall_count"]
+    ax_prog.plot(x, ic, color=STALL_COLORS["issue"], lw=2.5, label="Issuing")
+    ax_prog.fill_between(x, 0, ic, color=STALL_COLORS["issue"], alpha=0.18)
+    ax_prog.plot(x, sc, color="#4d4d4d", lw=2.0, label="Stalled")
+    ax_prog.fill_between(x, 0, sc, color="#4d4d4d", alpha=0.10)
+    ax_prog.set_ylim(
+        0, max(1.0, float(np.nanmax([ic.max(), sc.max()])) * 1.08))
+    ax_prog.set_title("1. Progress: issuing vs stalled cores")
+    ax_prog.set_ylabel("Cores")
+    ax_prog.grid(True, axis="y", alpha=0.25)
+    _agg_ticks(ax_prog, agg)
+    ax_prog.legend(loc="upper right", frameon=True, fancybox=True,
+                   edgecolor="#CCCCCC", facecolor="white", framealpha=0.9,
+                   ncol=2, handleheight=1.7, handlelength=2.5)
+
+    # 2 — stall composition
+    arrays = [agg["overall"]["stall_reason_count"][c]
+              for c in STALL_CATEGORIES]
+    colors = [STALL_COLORS[c] for c in STALL_CATEGORIES]
+    ax_mix.stackplot(
+        x,
+        arrays,
+        labels=[
+            stall_label(c) for c in STALL_CATEGORIES],
+        colors=colors,
+        alpha=0.95)
+    total = np.sum(np.vstack(arrays), axis=0)
+    ax_mix.set_ylim(0, max(1.0, float(np.nanmax(total)) * 1.08))
+    ax_mix.set_title("2. Stall composition by cause")
+    ax_mix.set_ylabel("Stalled cores")
+    ax_mix.grid(True, axis="y", alpha=0.25)
+    _agg_ticks(ax_mix, agg)
+    ax_mix.legend(loc="upper right", ncol=3, frameon=True, fancybox=True,
+                  edgecolor="#CCCCCC", facecolor="white", framealpha=0.9,
+                  handleheight=1.7, handlelength=2.5)
+
+    # 3 — stall fraction for tiles with observed activity
+    all_activity = agg["context_issue_count"] + agg["context_stall_count"]
+    active_mask = np.any(all_activity > 0, axis=1)
+    active_indices = np.where(active_mask)[0]
+    if len(active_indices) == 0:
+        active_indices = np.arange(len(agg["context_values"]))
+    active_labels = [str(agg["context_values"][i]) for i in active_indices]
+
+    issue_mat = agg["context_issue_count"][active_indices, :]
+    stall_mat = agg["context_stall_count"][active_indices, :]
+    total_mat = issue_mat + stall_mat
+    with np.errstate(divide="ignore", invalid="ignore"):
+        stall_frac = np.where(total_mat > 0, stall_mat / total_mat, np.nan)
+
+    img = ax_hm.imshow(stall_frac, aspect="auto", interpolation="nearest",
+                       cmap="RdYlGn_r", vmin=0, vmax=1, origin="lower")
+    ax_hm.set_facecolor("#E0E0E0")
+    ax_hm.set_title(
+        "3. Per-tile stall fraction (green = issuing, red = stalled)")
+    ax_hm.set_ylabel("Tile")
+    ax_hm.set_xlabel("Cycle")
+    _agg_ticks(ax_hm, agg)
+    n_active = len(active_indices)
+    if n_active <= 32:
+        ax_hm.set_yticks(np.arange(n_active))
+        ax_hm.set_yticklabels(active_labels)
+    else:
+        step = max(1, n_active // 16)
+        shown = list(range(0, n_active, step))
+        if (n_active - 1) not in shown:
+            shown.append(n_active - 1)
+        ax_hm.set_yticks(shown)
+        ax_hm.set_yticklabels([active_labels[i] for i in shown])
+    cbar = fig.colorbar(img, ax=ax_hm, fraction=0.028, pad=0.02)
+    cbar.set_label("Stall fraction")
+    cbar.set_ticks([0, 0.25, 0.5, 0.75, 1.0])
+    cbar.set_ticklabels(["0%\n(all issuing)", "25%",
+                        "50%", "75%", "100%\n(all stalled)"])
+
+    fig.suptitle("Cluster Stall Overview", fontsize=17, fontweight="bold")
+    fig.text(0.01, -0.005,
+             f"Reconstructed from annotated traces, not a true cycle logger. "
+             f"Filters: {filter_desc}. Window={window} cycles.",
+             fontsize=9, alpha=0.82, va="top")
+    fig.savefig(path, dpi=96, bbox_inches="tight")
+    plt.close(fig)
+
+
+def build_group_overview_stats(rows):
+    """Aggregate issue/stall/core-cycle statistics by group."""
+    if not rows:
+        raise ValueError("No rows for group overview")
+
+    groups = sorted({row["group"]
+                    for row in rows if row.get("group") is not None})
+    min_cycle = min(row["cycle"] for row in rows)
+    max_cycle = max(row["cycle"] for row in rows)
+    elapsed_cycles = max(1, max_cycle - min_cycle + 1)
+    stats = {
+        group: {
+            "issue": 0.0,
+            "stall": 0.0,
+            "mix": {category: 0.0 for category in STALL_CATEGORIES},
+        }
+        for group in groups
+    }
+
+    for row in rows:
+        group = row.get("group")
+        if group not in stats:
+            continue
+        if row["state"] == "issue":
+            stats[group]["issue"] += 1.0
+        else:
+            stats[group]["stall"] += 1.0
+            cats = split_stall_kind(row["stall_kind"])
+            weight = 1.0 / len(cats)
+            for category in cats:
+                stats[group]["mix"][category] += weight
+
+    return {
+        "groups": groups,
+        "elapsed_cycles": elapsed_cycles,
+        "stats": stats,
+    }
+
+
+def _annotate_stacked_barh(ax, left, width, y, total, label):
+    if total <= 0 or width / total <= 0.04:
+        return
+    pct = width / total * 100.0
+    text = f"{pct:.1f}%"
+    if width / total > 0.10:
+        text = f"{label}\n{pct:.1f}%\n{int(width)} cyc."
+    ax.text(left + width / 2, y, text, ha="center", va="center",
+            fontsize=9, fontweight="bold", color="white")
+
+
+def write_group_overview_page(path, group_stats, filter_desc):
+    """Plot per-group IPC and issuing/stalled core-cycle breakdowns."""
+    groups = group_stats["groups"]
+    stats = group_stats["stats"]
+    elapsed_cycles = group_stats["elapsed_cycles"]
+    y = np.arange(len(groups))
+
+    issue_vals = np.array([stats[group]["issue"]
+                          for group in groups], dtype=float)
+    stall_vals = np.array([stats[group]["stall"]
+                          for group in groups], dtype=float)
+    totals = issue_vals + stall_vals
+    ipc_vals = np.divide(
+        issue_vals,
+        totals,
+        out=np.zeros_like(issue_vals),
+        where=totals > 0)
+
+    fig, axes = plt.subplots(3, 1, figsize=(15, 12), constrained_layout=True,
+                             gridspec_kw={"height_ratios": [1.0, 1.15, 1.35]})
+    ax_ipc, ax_state, ax_mix = axes
+
+    # 1. Group IPC.
+    ax_ipc.bar(y, ipc_vals, color=STALL_COLORS["issue"], edgecolor="white",
+               linewidth=0.7)
+    ax_ipc.set_xticks(y)
+    ax_ipc.set_xticklabels([f"Group {group}" for group in groups])
+    ax_ipc.set_ylabel("Instructions / core-cycle")
+    ax_ipc.set_title("1. Group average per-core IPC")
+    ax_ipc.grid(True, axis="y", alpha=0.25)
+    ax_ipc.set_ylim(0, 1)
+    for xpos, value in zip(y, ipc_vals):
+        ax_ipc.text(xpos, value, f"{value:.2f}", ha="center", va="bottom",
+                    fontsize=9, fontweight="bold", color="#333333")
+
+    # 2. Issue/stall cycle split, with stall causes expanded in-place.
+    left = np.zeros(len(groups))
+    ax_state.barh(y, issue_vals, left=left, color=STALL_COLORS["issue"],
+                  edgecolor="white", linewidth=0.5, label="Issuing")
+    for idx, width in enumerate(issue_vals):
+        _annotate_stacked_barh(
+            ax_state,
+            left[idx],
+            width,
+            y[idx],
+            totals[idx],
+            "Issuing")
+    left += issue_vals
+
+    for category in STALL_CATEGORIES:
+        values = np.array([stats[group]["mix"][category]
+                          for group in groups], dtype=float)
+        ax_state.barh(
+            y,
+            values,
+            left=left,
+            color=STALL_COLORS[category],
+            edgecolor="white",
+            linewidth=0.5,
+            label=stall_label(category))
+        for idx, width in enumerate(values):
+            _annotate_stacked_barh(
+                ax_state,
+                left[idx],
+                width,
+                y[idx],
+                totals[idx],
+                stall_label(category))
+        left += values
+
+    ax_state.set_yticks(y)
+    ax_state.set_yticklabels([f"Group {group}" for group in groups])
+    ax_state.set_xlabel("Core-cycles")
+    ax_state.set_title("2. Core-cycle breakdown: issuing and stall causes")
+    ax_state.grid(True, axis="x", alpha=0.25)
+    ax_state.legend(loc="center left", bbox_to_anchor=(1.005, 0.5), ncol=1,
+                    frameon=True, fancybox=True,
+                    edgecolor="#CCCCCC", facecolor="white", framealpha=0.9,
+                    handleheight=1.15, handlelength=2.5)
+
+    # 3. Stall breakdown by reason.
+    left = np.zeros(len(groups))
+    for category in STALL_CATEGORIES:
+        values = np.array([stats[group]["mix"][category]
+                          for group in groups], dtype=float)
+        ax_mix.barh(
+            y,
+            values,
+            left=left,
+            color=STALL_COLORS[category],
+            edgecolor="white",
+            linewidth=0.5,
+            label=stall_label(category))
+        for idx, width in enumerate(values):
+            _annotate_stacked_barh(
+                ax_mix, left[idx], width, y[idx], max(
+                    stall_vals[idx], 1.0), stall_label(category))
+        left += values
+    ax_mix.set_yticks(y)
+    ax_mix.set_yticklabels([f"Group {group}" for group in groups])
+    ax_mix.set_xlabel("Stalled core-cycles")
+    ax_mix.set_title("3. Stall breakdown by cause")
+    ax_mix.grid(True, axis="x", alpha=0.25)
+    ax_mix.legend(loc="center left", bbox_to_anchor=(1.005, 0.5), ncol=1,
+                  frameon=True, fancybox=True,
+                  edgecolor="#CCCCCC", facecolor="white", framealpha=0.9,
+                  handleheight=1.15, handlelength=2.5)
+
+    fig.suptitle(
+        "Per-Group IPC and Core-Cycle Breakdown",
+        fontsize=17,
+        fontweight="bold")
+    fig.text(
+        0.01, -0.005,
+        f"Filters: {filter_desc}. "
+        f"IPC = issuing core-cycles / observed core-cycles; "
+        f"elapsed section span={elapsed_cycles} cycles.", fontsize=9,
+        alpha=0.82, va="top")
+    fig.savefig(path, dpi=96, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Tile-Detail Figure
+# ---------------------------------------------------------------------------
+
+def write_tile_detail(png_path, ts):
+    """All-in-one tile detail figure.
+
+    Subplot order (top to bottom):
+      1. Per-core state heatmap (stall subtypes)
+      2. Core-cycle breakdown bar
+      3. Current stall causes
+      4. Cumulative stall causes
+    """
+    tid = ts["tile_id"]
+    cycles = ts["cycles"]
+    cats = ts["present_categories"]
+
+    nrows = 4
+    ratios = [1.2, 0.8, 1.5, 1.5]
+    fig, axes = plt.subplots(nrows, 1, figsize=(20, 29),
+                             gridspec_kw={"height_ratios": ratios},
+                             constrained_layout=True)
+    row = 0
+
+    # ── 1. per-core state heatmap (stall subtype colours) ────────────────
+    n_cats = len(STALL_CATEGORIES)  # 6
+    hm_colors = ["#FFFFFF", STALL_COLORS["issue"]] + \
+        [STALL_COLORS[c] for c in STALL_CATEGORIES]
+    hm_cmap = plt.matplotlib.colors.ListedColormap(hm_colors)
+    axes[row].imshow(
+        ts["per_core_state"],
+        aspect="auto",
+        interpolation="nearest",
+        cmap=hm_cmap,
+        vmin=0,
+        vmax=1 + n_cats,
+        origin="lower")
+    axes[row].set_title("Per-Core Execution State by Stall Cause")
+    axes[row].set_ylabel("Core in tile")
+    axes[row].set_yticks(np.arange(len(ts["cores"])))
+    axes[row].set_yticklabels([str(c) for c in ts["cores"]])
+    axes[row].set_yticks(np.arange(-0.5, len(ts["cores"]), 1.0), minor=True)
+    axes[row].grid(which="minor", axis="y", color="#F2F2F2", linewidth=2.0)
+    axes[row].tick_params(which="minor", left=False)
+    set_cycle_ticks(axes[row], np.arange(len(cycles)), cycles)
+    hm_handles = [Patch(facecolor=STALL_COLORS["issue"], edgecolor="black",
+                        linewidth=0.5, label="Issuing")] + \
+        [Patch(facecolor=STALL_COLORS[c], edgecolor="black", linewidth=0.5,
+               label=stall_label(c)) for c in cats]
+    axes[row].legend(handles=hm_handles, loc="lower left",
+                     bbox_to_anchor=(0, 1.02), frameon=True, fancybox=True,
+                     edgecolor="#CCCCCC", facecolor="white", framealpha=0.9,
+                     ncol=len(hm_handles),
+                     handleheight=1.15, handlelength=2.5)
+    axes[row].set_xlabel("Cycle")
+    row += 1
+
+    # ── 2. stacked horizontal bar: summed core-cycle breakdown ───────────
+    total = float(ts["issue_cumulative"][-1] + ts["stall_cumulative"][-1])
+    bar_labels = ["Issuing"] + [stall_label(c) for c in cats]
+    bar_values = [float(ts["issue_cumulative"][-1])] + \
+        [float(ts["category_cumulative"][c][-1]) for c in cats]
+    bar_colors = [STALL_COLORS["issue"]] + [STALL_COLORS[c] for c in cats]
+
+    ax_bar = axes[row]
+    left = 0.0
+    for lbl, val, col in zip(bar_labels, bar_values, bar_colors):
+        pct = val / total * 100 if total else 0
+        count_text = f"{int(val)} cyc."
+        ax_bar.barh(
+            "Core-cycles",
+            val,
+            left=left,
+            color=col,
+            edgecolor="white",
+            linewidth=0.5,
+            label=f"{lbl} ({pct:.1f}%)")
+        if val / total > 0.10:
+            ax_bar.text(
+                left + val / 2,
+                0,
+                f"{lbl}\n{pct:.1f}%\n{count_text}",
+                ha="center",
+                va="center",
+                fontsize=9,
+                fontweight="bold",
+                color="white")
+        elif val / total > 0.04:
+            medium_text = f"{pct:.1f}%\n{count_text}"
+            ax_bar.text(
+                left + val / 2,
+                0,
+                medium_text,
+                ha="center",
+                va="center",
+                fontsize=9,
+                fontweight="bold",
+                color="white")
+        left += val
+    ax_bar.set_xlim(0, total)
+    ax_bar.set_xlabel("Core-cycle amount")
+    ax_bar.set_title(
+        f"Tile Summed Core-Cycle Breakdown  ({int(total)} total "
+        f"core-cycles across {len(ts['cores'])} cores)")
+    ax_bar.legend(
+        loc="upper left",
+        frameon=True,
+        fancybox=True,
+        edgecolor="#CCCCCC",
+        facecolor="white",
+        framealpha=0.9,
+        ncol=1,
+        handleheight=1.15,
+        handlelength=2.5)
+    row += 1
+
+    # ── 3. current stall causes ──────────────────────────────────────────
+    plot_categories_current(axes[row], cycles, ts["category_current"], cats,
+                            "Current Stall Causes",
+                            ylabel="Total stalled cores")
+    axes[row].set_xlabel("Cycle")
+    set_cycle_ticks(axes[row], cycles)
+    row += 1
+
+    # ── 4. cumulative stall causes ───────────────────────────────────────
+    plot_categories_cumulative(
+        axes[row],
+        cycles,
+        ts["category_cumulative"],
+        cats,
+        "Cumulative Stall Causes")
+    axes[row].set_xlabel("Cycle")
+    set_cycle_ticks(axes[row], cycles)
+    row += 1
+
+    fig.suptitle(f"Tile {tid} Detail Report", fontsize=17, fontweight="bold")
+
+    fig.savefig(png_path, dpi=96, bbox_inches="tight")
+    plt.close(fig)

--- a/hardware/scripts/trace_analysis/plot/plot_all_tiles.py
+++ b/hardware/scripts/trace_analysis/plot/plot_all_tiles.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analyze benchmark stall data and generate overview and tile-detail plots.
+
+The run's topology.env and stall CSV determine the available tiles and their
+group/subgroup output directories. Each tile-detail plot shows its cores'
+execution states and stall causes over time. Normal users should invoke
+`make plots`; this script is its direct implementation.
+"""
+
+import argparse
+import csv
+import multiprocessing
+import sys
+from pathlib import Path
+
+_root = str(Path(__file__).resolve().parent.parent)
+if _root not in sys.path:
+    sys.path.insert(0, _root)
+
+from _workflow_metadata import describe, load_topology  # noqa: E402
+import _stall_plots as stall_plots  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Topology and Data Preparation
+# ---------------------------------------------------------------------------
+
+
+def tile_output_dir(plots_dir, topo, tile_id):
+    """Compute the output directory for a given tile ID."""
+    group = tile_id // topo["tiles_per_group"]
+    if topo["n_subgroups_per_group"] > 1:
+        subgroup = ((tile_id % topo["tiles_per_group"])
+                    // topo["tiles_per_subgroup"])
+        return plots_dir / f"group{group}" / f"subgroup{subgroup}"
+    return plots_dir / f"group{group}"
+
+
+def discover_tile_ids(csv_path):
+    """Read unique tile IDs from the CSV."""
+    tiles = set()
+    with csv_path.open(newline="") as f:
+        for row in csv.DictReader(f):
+            val = row.get("tile", "").strip()
+            if val:
+                tiles.add(int(val))
+    return sorted(tiles)
+
+
+def group_rows_by_tile(rows):
+    grouped = {}
+    for row in rows:
+        tile_id = row.get("tile")
+        if tile_id is None:
+            continue
+        grouped.setdefault(tile_id, []).append(row)
+    return grouped
+
+
+def validate_tiles(topo, tile_ids):
+    if not tile_ids:
+        raise ValueError('No tile IDs found in CSV')
+    n_tiles = topo['n_tiles']
+    invalid = [tile_id for tile_id in tile_ids
+               if tile_id < 0 or tile_id >= n_tiles]
+    if invalid:
+        raise ValueError(
+            f'Tiles {invalid[:5]} do not fit the topology '
+            f'(expected tile IDs in [0, {n_tiles - 1}])')
+
+
+def _filter_description(sections):
+    if not sections:
+        return "all rows"
+    values = ",".join(str(value) for value in sorted(set(sections)))
+    return f"section={values}"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Analyze stall data and generate overview and tile-detail "
+                    "plots. A tile-detail plot shows per-core execution state "
+                    "and stall causes for one tile.")
+    p.add_argument(
+        "result_dir",
+        help="Benchmark result directory "
+             "(e.g. results/matmul_i32_mempool/das)")
+    p.add_argument("--section", type=int, action="append",
+                   help="Filter by section (repeatable)")
+    p.add_argument(
+        "--overview",
+        action="store_true",
+        help="Also generate cluster overview and per-group breakdown pages")
+    p.add_argument("--skip-tile-details", action="store_true",
+                   help="Skip per-tile detail pages")
+    p.add_argument("--window", type=int, default=64,
+                   help="Time-series bin width in cycles (default: 64)")
+    p.add_argument("--jobs", "-j", type=int, default=1,
+                   help="Number of parallel tile-plot workers (default: 1)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print what would be done without executing")
+    args = p.parse_args(argv)
+    if args.window <= 0:
+        p.error("--window must be positive")
+    if args.jobs <= 0:
+        p.error("--jobs must be positive")
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Tile Plot Generation
+# ---------------------------------------------------------------------------
+
+def _render_tile(item):
+    """Render one tile page and return its tile ID and any error."""
+    tid, out_dir, tile_rows = item
+    try:
+        if not tile_rows:
+            raise ValueError(f"No rows for tile {tid}")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        ts = stall_plots.build_tile_series(tile_rows, tid)
+        stall_plots.write_tile_detail(
+            out_dir / f"tile_detail_tile{tid}.png", ts)
+        return (tid, None)
+    except Exception as e:
+        return (tid, str(e))
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    args = parse_args(argv)
+    result_dir = Path(args.result_dir).resolve()
+
+    # Resolve the run inputs and topology.
+    csv_path = result_dir / "data" / "stall_timeseries_benchmark.csv"
+    plots_dir = result_dir / "plots"
+
+    if not csv_path.is_file():
+        sys.exit(f"CSV not found: {csv_path}")
+
+    try:
+        topo = load_topology(result_dir / "topology.env")
+    except ValueError as exc:
+        sys.exit(str(exc))
+
+    print(f"Topology: {describe(topo)}")
+    print(f"CSV:      {csv_path}")
+    print(f"Plots:    {plots_dir}")
+
+    # Load rows when rendering needs them; otherwise discover only tile IDs.
+    rows = None
+    needs_rows = not args.dry_run and (
+        args.overview or not args.skip_tile_details)
+    if needs_rows:
+        print("Loading stall CSV ...", flush=True)
+        rows = stall_plots.filter_rows(
+            stall_plots.load_rows(csv_path), section=args.section)
+        if not rows:
+            sys.exit("No rows after filtering")
+        tile_ids = sorted({row["tile"] for row in rows
+                           if row.get("tile") is not None})
+    else:
+        tile_ids = discover_tile_ids(csv_path)
+
+    try:
+        validate_tiles(topo, tile_ids)
+    except ValueError as exc:
+        sys.exit(str(exc))
+
+    print(f"Tiles:    {len(tile_ids)} ({tile_ids[0]}–{tile_ids[-1]})")
+    print()
+
+    # Prepare the requested overview and tile-detail outputs.
+    overview_dir = plots_dir / "overview"
+    digits = len(str(max(topo["n_tiles"] - 1, 1)))
+
+    work_items = []
+    if args.skip_tile_details:
+        print("Tile details: skipped (--skip-tile-details)")
+    else:
+        for tid in tile_ids:
+            out_dir = tile_output_dir(plots_dir, topo, tid)
+            work_items.append((tid, out_dir))
+
+    if args.dry_run:
+        if args.overview:
+            print(f"[dry-run] overview → {overview_dir}")
+        for tid, out_dir in work_items:
+            label = (
+                f"tile {tid:0{digits}d} → "
+                f"{out_dir.relative_to(plots_dir)}")
+            print(f"[dry-run] {label}")
+        return
+
+    rows_by_tile = group_rows_by_tile(rows) if work_items else {}
+    failed = []
+
+    if args.overview:
+        overview_dir.mkdir(parents=True, exist_ok=True)
+        filter_desc = _filter_description(args.section)
+
+        print(f"Overview → {overview_dir}")
+        agg = stall_plots.aggregate_rows(
+            rows, args.window, context_field="tile")
+        stall_plots.write_overview_page(
+            overview_dir / "overview_workload.png",
+            agg, filter_desc, args.window)
+        group_stats = stall_plots.build_group_overview_stats(rows)
+        stall_plots.write_group_overview_page(
+            overview_dir / "group_ipc_breakdown.png",
+            group_stats, filter_desc)
+        print()
+
+    if work_items:
+        n_jobs = min(args.jobs, len(work_items))
+
+        if n_jobs <= 1:
+            for i, (tid, out_dir) in enumerate(work_items, 1):
+                label = (f"[{i}/{len(work_items)}] tile {tid:0{digits}d} "
+                         f"→ {out_dir.relative_to(plots_dir)}")
+                print(label, end=" ... ", flush=True)
+                _, error = _render_tile(
+                    (tid, out_dir, rows_by_tile.get(tid)))
+                if error is None:
+                    print("ok")
+                else:
+                    print(f"FAILED: {error}")
+                    failed.append((tid, error))
+        else:
+            print(
+                f"Generating {len(work_items)} tile plots "
+                f"with {n_jobs} parallel workers ...")
+            # Use spawn context to avoid fork-safety issues with matplotlib.
+            # Each worker receives its tile's already-parsed rows, so the
+            # CSV is only read once, in this process.
+            ctx = multiprocessing.get_context("spawn")
+            payloads = [(tid, out_dir, rows_by_tile.get(tid))
+                        for tid, out_dir in work_items]
+            with ctx.Pool(n_jobs) as pool:
+                results = pool.map(_render_tile, payloads)
+            for tid, err in results:
+                if err is not None:
+                    failed.append((tid, err))
+            print(f"  {len(work_items) - len(failed)} ok, "
+                  f"{len(failed)} failed")
+
+    # Report generated outputs and any per-tile failures.
+    parts = []
+    if args.skip_tile_details:
+        parts.append("tile details skipped")
+    else:
+        generated = len(work_items) - len(failed)
+        parts.append(f"{generated} tile details generated")
+    if args.overview:
+        parts.append("overview generated")
+    if failed:
+        parts.append(f"{len(failed)} failed")
+    print(f"\nDone: {' / '.join(parts)}  ({len(tile_ids)} total)")
+    if failed:
+        print("Failed tiles:")
+        for tid, err in failed:
+            print(f"  tile {tid}: {err}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/scripts/trace_analysis/plot/plot_comm.py
+++ b/hardware/scripts/trace_analysis/plot/plot_comm.py
@@ -1,0 +1,1399 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analyze benchmark communication data and generate traffic and latency plots.
+
+Usage:
+    python plot_comm.py <result_dir> [--section 1] [--window 64]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+_root = str(Path(__file__).resolve().parent.parent)
+if _root not in sys.path:
+    sys.path.insert(0, _root)
+
+from _workflow_metadata import load_topology  # noqa: E402
+
+import matplotlib  # noqa: E402
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import matplotlib.gridspec as gridspec  # noqa: E402
+from matplotlib.patches import Rectangle  # noqa: E402
+from matplotlib.colors import (  # noqa: E402
+    LinearSegmentedColormap,
+    LogNorm,
+    Normalize,
+    PowerNorm,
+)
+from mpl_toolkits.axes_grid1 import make_axes_locatable  # noqa: E402
+import numpy as np  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Plot Style
+# ---------------------------------------------------------------------------
+
+FONT_SUBTITLE = 11
+FONT_LABEL = 10.5
+FONT_TICK = 9
+FONT_ANNOT = 8.5
+FONT_LEGEND = 9
+
+# Colorblind-safe palette (Okabe-Ito-inspired)
+COL_LOCAL = "#0072B2"   # blue  – local / intra-tile
+COL_SAME_SUB = "#009E73"  # green – same subgroup, different tile
+COL_SAME_GRP = "#56B4E9"  # sky blue – same group, different tile
+COL_REMOTE = "#D55E00"  # vermillion – remote / inter-group
+COL_ACCENT = "#E69F00"  # amber – highlights / p95
+COL_NEUTRAL = "#999999"
+
+GRP_COLORS = ["#0072B2", "#E69F00", "#009E73", "#CC79A7"]
+LATENCY_CMAP_COLORS = (
+    "#1a9641", "#55b748", "#91cf60", "#d0ec8a", "#f0f4a4",
+    "#fee08b", "#fdae61", "#f46d43", "#d73027", "#a50026",
+)
+
+DPI = 300
+FIG_TEXT_COLOR = "#222222"
+MATRIX_ANNOTATION_LIMIT = 64
+
+LOCALITY_LABELS = {
+    "local": "Same tile",
+    "same_subgroup": "Same subgroup",
+    "same_group": "Same group",
+    "remote": "Other group",
+}
+
+
+def _apply_style():
+    """Configure matplotlib for publication-quality output."""
+    plt.rcParams.update({
+        "font.family": "serif",
+        "font.size": FONT_TICK,
+        "axes.titlesize": FONT_SUBTITLE,
+        "axes.labelsize": FONT_LABEL,
+        "axes.edgecolor": "#444444",
+        "axes.linewidth": 0.7,
+        "axes.facecolor": "white",
+        "figure.facecolor": "white",
+        "xtick.labelsize": FONT_TICK,
+        "ytick.labelsize": FONT_TICK,
+        "xtick.direction": "out",
+        "ytick.direction": "out",
+        "xtick.major.size": 3.5,
+        "ytick.major.size": 3.5,
+        "xtick.minor.size": 2.0,
+        "ytick.minor.size": 2.0,
+        "legend.fontsize": FONT_LEGEND,
+        "legend.frameon": True,
+        "legend.framealpha": 0.92,
+        "legend.edgecolor": "#cccccc",
+        "legend.fancybox": True,
+        "grid.alpha": 0.25,
+        "grid.color": "#888888",
+        "grid.linewidth": 0.5,
+        "savefig.bbox": "tight",
+        "savefig.pad_inches": 0.08,
+        "text.color": FIG_TEXT_COLOR,
+        "axes.labelcolor": FIG_TEXT_COLOR,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Data Loading
+# ---------------------------------------------------------------------------
+
+def _int(value):
+    return None if value is None or value == "" else int(value)
+
+
+def _iter_events(path: Path, section):
+    """Yield selected CSV rows without retaining the event file."""
+    with path.open(newline="") as f:
+        for row in csv.DictReader(f):
+            if section is None or _int(row.get("section")) == section:
+                yield row
+
+
+# ---------------------------------------------------------------------------
+# Communication Aggregation
+# ---------------------------------------------------------------------------
+
+def _classify_locality(row):
+    """Return the most specific source-to-destination locality class."""
+    if _int(row.get("is_local")) == 1:
+        return "local"
+    if _int(row.get("is_same_subgroup")) == 1:
+        return "same_subgroup"
+    if _int(row.get("is_same_group")) == 1:
+        return "same_group"
+    return "remote"
+
+
+def _scan_events(events, topology):
+    """Collect fixed-size aggregates and cycle bounds in one CSV pass."""
+    n_groups = topology["n_groups"]
+    n_tiles = topology["n_tiles"]
+    tiles_per_group = topology["tiles_per_group"]
+    tile_matrix = np.zeros((n_tiles, n_tiles), dtype=float)
+    group_matrix = np.zeros((n_groups, n_groups), dtype=float)
+    pair_data = defaultdict(
+        lambda: {"count": 0, "lat_sum": 0.0, "locality": "remote"})
+
+    event_count = 0
+    min_cycle = None
+    max_cycle = None
+    has_traffic = False
+
+    for row in events:
+        event_count += 1
+        cycle_s = row.get("cycle")
+        if cycle_s not in (None, ""):
+            cycle = int(cycle_s)
+            min_cycle = cycle if min_cycle is None else min(
+                min_cycle, cycle)
+            max_cycle = cycle if max_cycle is None else max(
+                max_cycle, cycle)
+
+        event_type = (row.get("event_type") or "").strip()
+        if event_type in ("load_issue", "store_issue"):
+            dest_s = (row.get("dest_tile") or "").strip()
+            source = _int(row.get("tile"))
+            if dest_s:
+                dest = int(dest_s)
+                if (source is not None and 0 <= source < n_tiles and
+                        0 <= dest < n_tiles):
+                    has_traffic = True
+                    tile_matrix[source, dest] += 1
+                    group_matrix[
+                        source // tiles_per_group,
+                        dest // tiles_per_group,
+                    ] += 1
+
+        if event_type == "load_return":
+            source = _int(row.get("tile"))
+            dest_s = (row.get("dest_tile") or "").strip()
+            latency_s = row.get("latency", "")
+            if source is not None and dest_s and latency_s:
+                pair = pair_data[(source, int(dest_s))]
+                pair["count"] += 1
+                pair["lat_sum"] += float(latency_s)
+                pair["locality"] = _classify_locality(row)
+
+    cycle_bounds = ((min_cycle, max_cycle)
+                    if min_cycle is not None else None)
+    matrices = None
+    if has_traffic:
+        matrices = {"mat": tile_matrix, "gmat": group_matrix}
+    return {
+        "event_count": event_count,
+        "cycle_bounds": cycle_bounds,
+        "matrices": matrices,
+        "pair_data": pair_data,
+    }
+
+
+def _build_timeseries(events, topology, window_size, cycle_bounds):
+    """Bin issued requests and load-return latency into cycle windows."""
+    if window_size <= 0:
+        raise ValueError("window size must be positive")
+    if cycle_bounds is None:
+        return None
+    min_cycle, max_cycle = cycle_bounds
+    n_windows = (max_cycle - min_cycle) // window_size + 1
+    n_groups = topology["n_groups"]
+    n_tiles = topology["n_tiles"]
+    tiles_per_group = topology["tiles_per_group"]
+    localities = tuple(LOCALITY_LABELS)
+
+    requests = {name: np.zeros(n_windows) for name in localities}
+    incoming = np.zeros((n_tiles, n_windows))
+    latency_total = np.zeros((n_tiles, n_windows))
+    latency_count = np.zeros((n_tiles, n_windows), dtype=int)
+    locality_total = {
+        name: np.zeros((n_tiles, n_windows)) for name in localities}
+    locality_count = {
+        name: np.zeros((n_tiles, n_windows), dtype=int)
+        for name in localities
+    }
+    for r in events:
+        cyc_s = r.get("cycle", "")
+        tile_s = r.get("tile", "")
+        if not cyc_s or not tile_s:
+            continue
+        tile = int(tile_s)
+        column = (int(cyc_s) - min_cycle) // window_size
+        valid_tile = 0 <= tile < n_tiles
+
+        et = (r.get("event_type") or "").strip()
+        is_request = et in ("load_issue", "store_issue")
+        dest_s = (r.get("dest_tile") or "").strip()
+        # A request without a decoded destination has no known locality.
+        if is_request and valid_tile and dest_s:
+            locality = _classify_locality(r)
+            requests[locality][column] += 1
+
+        lat_s = r.get("latency", "")
+        if valid_tile and lat_s and et == "load_return":
+            lat = float(lat_s)
+            latency_total[tile, column] += lat
+            latency_count[tile, column] += 1
+            locality = _classify_locality(r)
+            locality_total[locality][tile, column] += lat
+            locality_count[locality][tile, column] += 1
+
+        if is_request and dest_s:
+            dest = int(dest_s)
+            if 0 <= dest < n_tiles:
+                incoming[dest, column] += 1
+
+    tile_latency = np.divide(
+        latency_total, latency_count,
+        out=np.full((n_tiles, n_windows), np.nan),
+        where=latency_count > 0)
+    system_total = latency_total.sum(axis=0)
+    system_count = latency_count.sum(axis=0)
+    group_shape = (n_groups, tiles_per_group, n_windows)
+    group_total = latency_total.reshape(group_shape).sum(axis=1)
+    group_count = latency_count.reshape(group_shape).sum(axis=1)
+    class_total = {
+        name: values.sum(axis=0)
+        for name, values in locality_total.items()
+    }
+    class_count = {
+        name: values.sum(axis=0)
+        for name, values in locality_count.items()
+    }
+
+    def averages(total, count):
+        return np.divide(total, count, out=np.full(total.shape, np.nan),
+                         where=count > 0)
+
+    cycle_centers = (
+        min_cycle + np.arange(n_windows) * window_size + window_size / 2.0)
+    group_cycles = np.tile(cycle_centers, (n_groups, 1))
+
+    return {
+        "cycles": cycle_centers,
+        "group_cycles": group_cycles,
+        "cycle_bounds": (
+            min_cycle,
+            min_cycle + n_windows * window_size - 1,
+        ),
+        "window_size": window_size,
+        "n_windows": n_windows,
+        "n_groups": n_groups,
+        "n_tiles": n_tiles,
+        "tiles_per_group": tiles_per_group,
+        "n_subgroups_per_group": topology["n_subgroups_per_group"],
+        "requests": requests,
+        "incoming": incoming,
+        "latency": {
+            "system": averages(system_total, system_count),
+            "group": averages(group_total, group_count),
+            "tile": tile_latency,
+            "locality": {
+                name: averages(class_total[name], class_count[name])
+                for name in localities
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared Figure Helpers
+# ---------------------------------------------------------------------------
+
+def _nice_count(value):
+    """Format a count for plot annotations (e.g., 1234 → '1.2k')."""
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
+    if value >= 1000:
+        return f"{value / 1000:.1f}k"
+    return f"{value:.0f}"
+
+
+def _add_subgroup_boxes(
+        ax, topology, tiles_per_group, n_groups, zorder_base=7):
+    """Draw subgroup boxes, boundaries, and labels on a tile matrix."""
+    tiles_per_subgroup = topology.get("tiles_per_subgroup")
+    n_subgroups = topology.get("n_subgroups_per_group")
+    n_tiles = n_groups * tiles_per_group
+    if (not tiles_per_subgroup or not n_subgroups or
+            tiles_per_subgroup >= tiles_per_group):
+        return
+
+    # Mark subgroup boundaries without redrawing group boundaries.
+    for boundary in range(tiles_per_subgroup, n_tiles, tiles_per_subgroup):
+        if boundary % tiles_per_group != 0:
+            ax.axhline(boundary - 0.5, color="#888888", lw=0.6,
+                       ls="--", alpha=0.5, zorder=3)
+            ax.axvline(boundary - 0.5, color="#888888", lw=0.6,
+                       ls="--", alpha=0.5, zorder=3)
+
+    # Outline same-subgroup blocks on the matrix diagonal.
+    for group in range(n_groups):
+        color = GRP_COLORS[group % len(GRP_COLORS)]
+        for subgroup in range(n_subgroups):
+            origin = (group * tiles_per_group +
+                      subgroup * tiles_per_subgroup - 0.5)
+            ax.add_patch(Rectangle(
+                (origin, origin), tiles_per_subgroup, tiles_per_subgroup,
+                linewidth=1.5, edgecolor=color,
+                facecolor="none", ls="--", alpha=0.7,
+                zorder=zorder_base, clip_on=False,
+            ))
+
+    # Label each subgroup between the group labels and tile tick labels.
+    for group in range(n_groups):
+        color = GRP_COLORS[group % len(GRP_COLORS)]
+        for subgroup in range(n_subgroups):
+            midpoint = (group * tiles_per_group +
+                        subgroup * tiles_per_subgroup +
+                        tiles_per_subgroup / 2)
+            ax.text(-0.02, midpoint, f"s{subgroup}",
+                    ha="right", va="center",
+                    fontsize=FONT_ANNOT - 1, color=color, alpha=0.6,
+                    transform=ax.get_yaxis_transform(), clip_on=False)
+            ax.text(midpoint, -0.03, f"s{subgroup}",
+                    ha="center", va="top",
+                    fontsize=FONT_ANNOT - 1, color=color, alpha=0.6,
+                    transform=ax.get_xaxis_transform(), clip_on=False)
+
+
+def _clean_spine(ax, top=False, right=False):
+    """Remove top/right spines and enable y-grid."""
+    ax.spines["top"].set_visible(top)
+    ax.spines["right"].set_visible(right)
+    ax.grid(axis="y", alpha=0.25)
+    ax.set_axisbelow(True)
+
+
+def _save(fig, output_dir, name, dpi=DPI):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_dir / f"{name}.png", dpi=dpi)
+    plt.close(fig)
+    print(f"  → {name}.png")
+
+
+def _matrix_pixel_budget(n_tiles):
+    return 8000 if n_tiles > MATRIX_ANNOTATION_LIMIT else 5400
+
+
+# ---------------------------------------------------------------------------
+# Group-to-Group Request Matrix
+# ---------------------------------------------------------------------------
+
+def plot_traffic_matrix_group(matrices, topology, output_dir, section):
+    """Plot issued request counts by source and destination group."""
+    n_groups = topology["n_groups"]
+    if matrices is None:
+        print("  [skip] No traffic data for matrix")
+        return
+
+    gmat = matrices["gmat"]
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+
+    fig, ax = plt.subplots(figsize=(7.2, 5.8))
+    gmax = gmat.max()
+    image = ax.imshow(
+        gmat,
+        origin="lower",
+        cmap="YlOrRd",
+        aspect="equal",
+        norm=Normalize(
+            vmin=0,
+            vmax=gmax),
+        interpolation="nearest")
+    for i in range(n_groups):
+        for j in range(n_groups):
+            val = gmat[i, j]
+            txt_col = "white" if val > gmax * 0.6 else FIG_TEXT_COLOR
+            if val > 0:
+                ax.text(
+                    j,
+                    i,
+                    _nice_count(val),
+                    ha="center",
+                    va="center",
+                    fontsize=FONT_ANNOT + 1,
+                    fontweight="bold",
+                    color=txt_col)
+    ax.set_xticks(range(n_groups))
+    ax.set_yticks(range(n_groups))
+    ax.set_xticklabels(
+        [f"Group {g}" for g in range(n_groups)], fontsize=FONT_TICK)
+    ax.set_yticklabels(
+        [f"Group {g}" for g in range(n_groups)], fontsize=FONT_TICK)
+    ax.set_xlabel("Destination group", fontsize=FONT_LABEL)
+    ax.set_ylabel("Source group", fontsize=FONT_LABEL)
+    ax.set_title("Group-to-group request volume (load/store issues)",
+                 fontsize=FONT_SUBTITLE, fontweight="bold", pad=10)
+    divider = make_axes_locatable(ax)
+    colorbar_ax = divider.append_axes("right", size="3.5%", pad=1.00)
+    colorbar = fig.colorbar(image, cax=colorbar_ax)
+    colorbar.set_label("Load/store issues", fontsize=FONT_LABEL - 1)
+    colorbar.ax.tick_params(labelsize=FONT_TICK - 1)
+
+    total = gmat.sum()
+    group_nonzero = int(np.count_nonzero(gmat))
+    fig.text(
+        0.5, -0.02,
+        f"{sec_lbl}  ·  {n_groups} groups  ·  "
+        f"{_nice_count(total)} requests  ·  "
+        f"{group_nonzero} active group pairs", ha="center",
+        fontsize=FONT_ANNOT, color="#666666", style="italic")
+
+    _save(fig, output_dir, "traffic_matrix_groups")
+
+
+# ---------------------------------------------------------------------------
+# Tile-to-Tile Request Matrix
+# ---------------------------------------------------------------------------
+
+def plot_traffic_matrix_full(matrices, topology, output_dir, section):
+    """Full-chip square tile-to-tile request heatmap (n_tiles × n_tiles).
+    All groups are shown on both axes so the matrix is always square."""
+    n_groups = topology["n_groups"]
+    if matrices is None:
+        print("  [skip] No traffic data for tile matrix")
+        return
+
+    mat = matrices["mat"]
+    n_tiles = topology["n_tiles"]
+    tiles_per_group = topology["tiles_per_group"]
+
+    # Scale matrix cells to keep annotations readable.
+    max_px = _matrix_pixel_budget(n_tiles)
+    cell_size = max(0.20, min(0.50, (max_px / DPI - 2.5) / max(n_tiles, 1)))
+    side_inches = max(6.0, n_tiles * cell_size)
+    fig_w = side_inches + 2.5  # colorbar + labels
+    fig_h = side_inches + 2.0  # title + xlabel
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h))
+
+    vmax = mat.max()
+    plot_matrix = mat.copy()
+    vmin = max(1.0, mat[mat > 0].min()) if np.any(mat > 0) else 1.0
+    plot_matrix[plot_matrix == 0] = np.nan
+    cmap = plt.cm.YlOrRd.copy()
+    cmap.set_bad(color="#F5F5F5")
+    im = ax.imshow(plot_matrix, origin="lower", cmap=cmap, aspect="equal",
+                   norm=LogNorm(vmin=vmin, vmax=vmax), interpolation="nearest")
+
+    # Annotate cells — font scales with cell size for readability.
+    if n_tiles <= MATRIX_ANNOTATION_LIMIT:
+        cell_pt = cell_size * 72
+        annot_fs = min(FONT_ANNOT, max(2.0, cell_pt * 0.28))
+        fw = "bold" if n_tiles <= 32 else "normal"
+        for i in range(n_tiles):
+            for j in range(n_tiles):
+                val = mat[i, j]
+                if val > 0:
+                    txt_col = (
+                        "white" if val > vmax * 0.3 else FIG_TEXT_COLOR)
+                    ax.text(j, i, _nice_count(val), ha="center", va="center",
+                            fontsize=annot_fs, fontweight=fw, color=txt_col)
+
+    # Group boundaries — source (y-axis)
+    for g in range(n_groups):
+        offset = g * tiles_per_group
+        if g > 0:
+            ax.axhline(offset - 0.5, color="#333333", lw=2.0, alpha=0.7)
+        mid = offset + tiles_per_group / 2
+        ax.text(-0.04, mid, f"G{g}", ha="right", va="center",
+                fontsize=FONT_ANNOT + 3, fontweight="bold",
+                color=GRP_COLORS[g % len(GRP_COLORS)],
+                transform=ax.get_yaxis_transform(), clip_on=False)
+
+    # Group boundaries — dest (x-axis)
+    for g in range(n_groups):
+        offset = g * tiles_per_group
+        if g > 0:
+            ax.axvline(offset - 0.5, color="#333333", lw=2.0, alpha=0.7)
+        mid = offset + tiles_per_group / 2
+        ax.text(mid, -0.06, f"G{g}", ha="center", va="top",
+                fontsize=FONT_ANNOT + 3, fontweight="bold",
+                color=GRP_COLORS[g % len(GRP_COLORS)],
+                transform=ax.get_xaxis_transform(), clip_on=False)
+
+    # Highlight self-group diagonal blocks
+    for g in range(n_groups):
+        origin = g * tiles_per_group - 0.5
+        rect_xy = (origin, origin)
+        gcol = GRP_COLORS[g % len(GRP_COLORS)]
+        ax.add_patch(Rectangle(
+            rect_xy, tiles_per_group, tiles_per_group,
+            linewidth=4.0, edgecolor="#000000",
+            facecolor="none", alpha=0.2, zorder=4, clip_on=False,
+        ))
+        ax.add_patch(Rectangle(
+            rect_xy, tiles_per_group, tiles_per_group,
+            linewidth=2.5, edgecolor=gcol,
+            facecolor="none", zorder=5, clip_on=False,
+        ))
+
+    # Highlight self-subgroup diagonal blocks
+    _add_subgroup_boxes(ax, topology, tiles_per_group, n_groups)
+
+    # Tick labels — show ticks at subgroup boundaries for readability
+    if n_tiles > 64:
+        _tps = topology.get("tiles_per_subgroup")
+        if _tps:
+            tick_positions = list(range(0, n_tiles, _tps))
+            if (n_tiles - 1) not in tick_positions:
+                tick_positions.append(n_tiles - 1)
+        else:
+            tick_positions = list(range(0, n_tiles, tiles_per_group))
+            tick_positions.append(n_tiles - 1)
+        tick_labels = [str(t) for t in tick_positions]
+        ax.set_xticks(tick_positions)
+        ax.set_yticks(tick_positions)
+        ax.set_xticklabels(tick_labels, fontsize=FONT_TICK - 1, rotation=90)
+        ax.set_yticklabels(tick_labels, fontsize=FONT_TICK - 1)
+    else:
+        tick_fs = max(6.5, FONT_TICK - 1.0 * (n_tiles > 48))
+        ax.set_xticks(range(n_tiles))
+        ax.set_yticks(range(n_tiles))
+        ax.set_xticklabels(range(n_tiles), fontsize=tick_fs, rotation=90)
+        ax.set_yticklabels(range(n_tiles), fontsize=tick_fs)
+    ax.set_xlabel("Destination tile", fontsize=FONT_LABEL, labelpad=20)
+    ax.set_ylabel("Source tile", fontsize=FONT_LABEL)
+
+    ax.set_title("Tile-to-tile request volume (load/store issues)",
+                 fontsize=FONT_SUBTITLE, fontweight="bold", pad=10)
+
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size="3.5%", pad=1.00)
+    cb = fig.colorbar(im, cax=cax)
+    cb.set_label("Load/store issues", fontsize=FONT_LABEL - 1)
+    # Use 1, 2.5, and 5 ticks per decade.
+    low, high = math.log10(max(vmin, 1)), math.log10(max(vmax, 1))
+    ticks = []
+    for exp in range(int(math.floor(low)), int(math.ceil(high)) + 1):
+        base = 10 ** exp
+        for mult in [1, 2.5, 5]:
+            v = base * mult
+            if vmin <= v <= vmax:
+                ticks.append(v)
+    if not ticks:
+        ticks = [vmin, vmax]
+    cb.set_ticks(ticks)
+    cb.set_ticklabels([_nice_count(tick) for tick in ticks])
+    cb.ax.tick_params(labelsize=FONT_TICK)
+
+    total = mat.sum()
+    nonzero = int(np.count_nonzero(mat))
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+    fig.text(0.5, -0.005,
+             f"{sec_lbl}  ·  {n_tiles} tiles  ·  {n_groups} groups  ·  "
+             f"{_nice_count(total)} requests  ·  {nonzero} active pairs",
+             ha="center", fontsize=FONT_ANNOT, color="#666666", style="italic")
+
+    _save(fig, output_dir, "traffic_matrix")
+
+
+# ---------------------------------------------------------------------------
+# Temporal Communication Profile
+# ---------------------------------------------------------------------------
+
+def plot_temporal_profile(
+        timeseries,
+        output_dir,
+        section):
+    """Plot three communication views over a shared cycle axis.
+
+      (a) Issued requests by topology-aware locality class
+      (b) Issued requests received by each physical destination tile
+      (c) Load-return latency, overall and by locality class
+    """
+    cycle_centers = timeseries["cycles"]
+    section_start_cycle, section_end_cycle = timeseries["cycle_bounds"]
+    n_windows = timeseries["n_windows"]
+    n_groups = timeseries["n_groups"]
+    n_tiles = timeseries["n_tiles"]
+    tiles_per_group = timeseries["tiles_per_group"]
+    requests = timeseries["requests"]
+    heatmap_in = timeseries["incoming"]
+    latency = timeseries["latency"]
+    rel_cycle_centers = cycle_centers - section_start_cycle
+    has_subgroups = (timeseries["n_subgroups_per_group"] or 1) > 1
+    display_localities = [
+        ("local", COL_LOCAL, LOCALITY_LABELS["local"], "Same-tile Avg."),
+    ]
+    if has_subgroups:
+        display_localities.extend([
+            ("same_subgroup", COL_SAME_SUB,
+             LOCALITY_LABELS["same_subgroup"], "Same-subgroup Avg."),
+            ("same_group", COL_SAME_GRP,
+             LOCALITY_LABELS["same_group"], "Same-group Avg."),
+        ])
+    else:
+        display_localities.append(
+            ("same_subgroup", COL_SAME_GRP, "Same group", "Same-group Avg."))
+    display_localities.append(
+        ("remote", COL_REMOTE, LOCALITY_LABELS["remote"],
+         "Other-group Avg."))
+
+    fig = plt.figure(figsize=(12.8, 10.8))
+    gs_fig = gridspec.GridSpec(
+        3, 2,
+        width_ratios=[40, 1.5],
+        height_ratios=[1.2, 1.5, 1.0],
+        hspace=0.34,
+        wspace=0.24,
+    )
+    x_min = 0
+    x_max = section_end_cycle - section_start_cycle
+    x_label = (f"Cycles (Section {section})"
+               if section is not None else "Cycles")
+
+    # (a) Issued requests stacked by locality class.
+    ax_a = fig.add_subplot(gs_fig[0, 0])
+    stack = np.zeros(n_windows)
+    for key, color, label, _ in display_localities:
+        next_stack = stack + requests[key]
+        ax_a.fill_between(rel_cycle_centers, stack, next_stack,
+                          step="mid", color=color,
+                          alpha=0.85 if key == "local" else 0.75,
+                          label=label)
+        stack = next_stack
+    ax_a.set_xlim(x_min, x_max)
+    ax_a.set_ylabel("Issued requests / window", fontsize=FONT_LABEL)
+    ax_a.set_title(
+        "(a)  Issued memory requests by locality class",
+        fontsize=FONT_SUBTITLE,
+        fontweight="bold",
+        pad=6,
+        loc="left")
+    ax_a.legend(loc="upper right", fontsize=FONT_LEGEND, ncol=2)
+    _clean_spine(ax_a)
+    ax_a.tick_params(labelbottom=True)
+    ax_a.set_xlabel(x_label, fontsize=FONT_LABEL, labelpad=2)
+
+    # (b) Issued requests grouped by their physical destination tile.
+    ax_b = fig.add_subplot(gs_fig[1, 0], sharex=ax_a)
+    extent = [0, x_max,
+              -0.5, n_tiles - 0.5]
+    vmax_heat = (np.percentile(heatmap_in[heatmap_in > 0], 95)
+                 if np.any(heatmap_in > 0) else 1)
+    cmap_heat = plt.cm.YlOrRd.copy()
+    cmap_heat.set_bad(color="#F5F5F5")
+    heat_plot = heatmap_in.copy()
+    heat_plot[heat_plot == 0] = np.nan
+    im_b = ax_b.imshow(heat_plot, aspect="auto", cmap=cmap_heat,
+                       vmin=0, vmax=vmax_heat, extent=extent,
+                       origin="lower", interpolation="nearest")
+    for g in range(1, n_groups):
+        ax_b.axhline(
+            g * tiles_per_group - 0.5,
+            color="#333333",
+            lw=0.8,
+            ls="--",
+            alpha=0.5)
+    for g in range(n_groups):
+        mid = g * tiles_per_group + tiles_per_group / 2 - 0.5
+        ax_b.text(1.003, mid, f"G{g}", ha="left", va="center",
+                  transform=ax_b.get_yaxis_transform(),
+                  fontsize=FONT_ANNOT, fontweight="bold",
+                  color=GRP_COLORS[g % len(GRP_COLORS)], clip_on=False)
+    ax_b.set_ylabel("Destination tile", fontsize=FONT_LABEL)
+    ax_b.set_title(
+        "(b)  Issued memory requests by destination tile over time",
+        fontsize=FONT_SUBTITLE,
+        fontweight="bold",
+        pad=6,
+        loc="left")
+    cax_b = fig.add_subplot(gs_fig[1, 1])
+    cb_b = fig.colorbar(im_b, cax=cax_b)
+    cb_b.set_label("Issued requests / window", fontsize=FONT_LABEL - 1)
+    cb_b.ax.tick_params(labelsize=FONT_TICK - 1)
+    ax_b.tick_params(labelbottom=True)
+    ax_b.set_xlabel(x_label, fontsize=FONT_LABEL, labelpad=2)
+    ax_b.set_yticks(np.arange(
+        0, n_tiles, max(1, tiles_per_group // 2)))
+
+    # (c) Mean load-return latency by locality class.
+    ax_c = fig.add_subplot(gs_fig[2, 0], sharex=ax_a)
+    system_latency = np.nan_to_num(latency["system"], nan=0.0)
+    ax_c.plot(rel_cycle_centers, system_latency, color=COL_REMOTE, lw=2.2,
+              zorder=3, label="Overall Avg.")
+    for key, color, _, label in display_localities:
+        values = np.nan_to_num(latency["locality"][key], nan=0.0)
+        line_color = COL_ACCENT if key == "remote" else color
+        ax_c.plot(rel_cycle_centers, values, color=line_color, lw=1.8,
+                  zorder=4, label=label)
+    ax_c.fill_between(
+        rel_cycle_centers,
+        0,
+        system_latency,
+        color=COL_REMOTE,
+        alpha=0.12)
+    ax_c.set_xlim(x_min, x_max)
+    ax_c.set_xlabel(x_label, fontsize=FONT_LABEL)
+    ax_c.set_ylabel("Latency (cycles; 0 = no returns)", fontsize=FONT_LABEL)
+    ax_c.set_title(
+        "(c)  Load-return latency over time by locality",
+        fontsize=FONT_SUBTITLE,
+        fontweight="bold",
+        pad=6,
+        loc="left")
+    ax_c.legend(loc="upper right", fontsize=FONT_LEGEND, ncol=2)
+    _clean_spine(ax_c)
+
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+    fig.text(
+        0.5, -0.005,
+        f"{sec_lbl}  ·  {n_tiles} tiles  ·  {n_windows} windows × "
+        f"{timeseries['window_size']} cycles  ·  "
+        f"Relative range: 0–{x_max:.0f}  ·  "
+        f"Absolute cycle range: "
+        f"{cycle_centers[0]:.0f}–{cycle_centers[-1]:.0f}",
+        ha="center", fontsize=FONT_ANNOT, color="#666666", style="italic")
+
+    _save(fig, output_dir, "overview_temporal")
+
+
+# ---------------------------------------------------------------------------
+# Load-Return Latency Over Time
+# ---------------------------------------------------------------------------
+
+def plot_latency_over_time(timeseries, output_dir, section):
+    """Standalone latency figure for cross-design comparison.
+    Two panels:
+      (a) System-wide average latency + min/max envelope
+      (b) Per-group average latency (one line per group)
+    """
+    cycle_centers = timeseries["cycles"]
+    n_windows = timeseries["n_windows"]
+    n_groups = timeseries["n_groups"]
+    n_tiles = timeseries["n_tiles"]
+    tiles_per_group = timeseries["tiles_per_group"]
+    sys_avg = timeseries["latency"]["system"]
+    grp_avg = timeseries["latency"]["group"]
+    tile_avgs = timeseries["latency"]["tile"]
+    tile_has_data = np.isfinite(tile_avgs).any(axis=0)
+    tile_min = np.full(n_windows, np.nan)
+    tile_max = np.full(n_windows, np.nan)
+    if tile_has_data.any():
+        valid_tile_avgs = tile_avgs[:, tile_has_data]
+        tile_min[tile_has_data] = np.nanmin(valid_tile_avgs, axis=0)
+        tile_max[tile_has_data] = np.nanmax(valid_tile_avgs, axis=0)
+
+    fig, (ax_a, ax_b) = plt.subplots(2, 1, figsize=(11, 7.5), sharex=True,
+                                     gridspec_kw={"hspace": 0.18})
+
+    # (a) System-wide
+    ax_a.fill_between(
+        cycle_centers,
+        tile_min,
+        tile_max,
+        color=COL_REMOTE,
+        alpha=0.12,
+        label="Tile min\u2013max range")
+    ax_a.plot(cycle_centers, sys_avg, color=COL_REMOTE, lw=2.5,
+              label="System average", zorder=3)
+    valid = ~np.isnan(sys_avg)
+    if valid.any():
+        mean_val = np.nanmean(sys_avg)
+        ax_a.axhline(mean_val, color=COL_NEUTRAL, lw=1.2, ls=":",
+                     alpha=0.6, zorder=1)
+        ax_a.text(cycle_centers[valid][-1], mean_val,
+                  f"  {mean_val:.1f} cyc", va="bottom", ha="left",
+                  fontsize=FONT_ANNOT, color=COL_NEUTRAL, fontstyle="italic")
+    ax_a.set_ylabel("Load-return latency (cycles)", fontsize=FONT_LABEL)
+    ax_a.set_title(
+        "(a)  System-wide average load-return latency",
+        fontsize=FONT_SUBTITLE,
+        fontweight="bold",
+        pad=6,
+        loc="left")
+    ax_a.legend(loc="upper right", fontsize=FONT_LEGEND)
+    _clean_spine(ax_a)
+
+    # (b) Per-group
+    for g in range(n_groups):
+        valid_g = ~np.isnan(grp_avg[g])
+        if not valid_g.any():
+            continue
+        ax_b.plot(cycle_centers, grp_avg[g],
+                  color=GRP_COLORS[g % len(GRP_COLORS)], lw=1.5,
+                  solid_capstyle="round", label=f"Group {g}", zorder=3)
+    ax_b.set_xlabel("Cycle", fontsize=FONT_LABEL)
+    ax_b.set_ylabel("Load-return latency (cycles)", fontsize=FONT_LABEL)
+    ax_b.set_title(
+        "(b)  Per-group average load-return latency",
+        fontsize=FONT_SUBTITLE,
+        fontweight="bold",
+        pad=6,
+        loc="left")
+    ax_b.legend(loc="upper right", fontsize=FONT_LEGEND, ncol=2,
+                handlelength=3.0, columnspacing=1.5)
+    _clean_spine(ax_b)
+
+    x_min = cycle_centers.min() - 20
+    x_max = cycle_centers.max() + 20
+    ax_a.set_xlim(x_min, x_max)
+
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+    fig.text(
+        0.5, -0.005,
+        f"{sec_lbl}  ·  {n_groups} groups × "
+        f"{tiles_per_group} tiles/group "
+        f"({n_tiles} tiles)  ·  "
+        f"{n_windows} windows \u00d7 {timeseries['window_size']} cycles",
+        ha="center",
+        fontsize=FONT_ANNOT, color="#666666", style="italic")
+
+    # Dense time-series lines benefit from a higher export resolution.
+    _save(fig, output_dir, "latency_timeseries", dpi=450)
+
+
+# ---------------------------------------------------------------------------
+# Per-Tile Latency Within a Source Group
+# ---------------------------------------------------------------------------
+
+def plot_per_tile_group_latency(timeseries, output_dir, section,
+                                target_group=0):
+    """Plot latency by source tile within one group and its group average."""
+    n_windows = timeseries["n_windows"]
+    n_tiles = timeseries["n_tiles"]
+    tiles_per_group = timeseries["tiles_per_group"]
+    grp_tiles = [
+        tile for tile in range(n_tiles)
+        if tile // tiles_per_group == target_group
+    ]
+    if not grp_tiles:
+        print(f"  [skip] No tiles in group {target_group}")
+        return
+
+    cycle_centers = timeseries["group_cycles"][target_group]
+    tile_avgs = timeseries["latency"]["tile"][grp_tiles]
+    grp_avg = timeseries["latency"]["group"][target_group]
+
+    fig, ax = plt.subplots(figsize=(11, 5.5))
+
+    # Individual tile lines (thin, distinct colors)
+    cmap_tiles = plt.cm.tab20(np.linspace(0, 1, len(grp_tiles)))
+    for ti, t in enumerate(grp_tiles):
+        valid = ~np.isnan(tile_avgs[ti])
+        if not valid.any():
+            continue
+        ax.plot(cycle_centers, tile_avgs[ti],
+                color=cmap_tiles[ti], lw=1.2, alpha=0.7,
+                solid_joinstyle="round", label=f"Tile {t}", zorder=2)
+
+    # Group average (bold)
+    ax.plot(cycle_centers, grp_avg, color="#222222", lw=2.0,
+            label=f"Group {target_group} avg", zorder=4)
+
+    # Overall mean reference
+    valid_avg = ~np.isnan(grp_avg)
+    if valid_avg.any():
+        mean_val = np.nanmean(grp_avg)
+        ax.axhline(mean_val, color=COL_NEUTRAL, lw=1.2, ls=":",
+                   alpha=0.6, zorder=1)
+        ax.text(cycle_centers[valid_avg][-1], mean_val,
+                f"  {mean_val:.1f} cyc", va="bottom", ha="left",
+                fontsize=FONT_ANNOT, color=COL_NEUTRAL, fontstyle="italic")
+
+    ax.set_xlabel("Cycle", fontsize=FONT_LABEL)
+    ax.set_ylabel("Load-return latency (cycles)", fontsize=FONT_LABEL)
+    ax.set_title(f"Per-source-tile load-return latency — Group {target_group} "
+                 f"(tiles {grp_tiles[0]}\u2013{grp_tiles[-1]})",
+                 fontsize=FONT_SUBTITLE, fontweight="bold", pad=10)
+    leg = ax.legend(loc="upper right", fontsize=FONT_LEGEND - 1, ncol=4,
+                    framealpha=0.9, handlelength=2.5)
+    for line in leg.get_lines():
+        line.set_linewidth(3.0)
+    _clean_spine(ax)
+
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+    fig.text(
+        0.5, -0.005,
+        f"{sec_lbl}  ·  Group {target_group}: "
+        f"{len(grp_tiles)} tiles  ·  "
+        f"{n_windows} windows \u00d7 {timeseries['window_size']} cycles",
+        ha="center",
+        fontsize=FONT_ANNOT, color="#666666", style="italic")
+
+    _save(fig, output_dir, f"latency_tile_g{target_group}")
+
+
+# ---------------------------------------------------------------------------
+# Tile-Pair Latency Heatmaps
+# ---------------------------------------------------------------------------
+
+class PiecewiseNorm(Normalize):
+    """Continuous color normalization with explicit value anchors."""
+
+    def __init__(self, x_points, y_points, vmin=None, vmax=None, clip=False):
+        super().__init__(vmin=vmin, vmax=vmax, clip=clip)
+        self.x_points = np.asarray(x_points, dtype=float)
+        self.y_points = np.asarray(y_points, dtype=float)
+
+    def __call__(self, value, clip=None):
+        result, is_scalar = self.process_value(value)
+        data = np.asarray(result.data, dtype=float)
+        mapped = np.interp(data, self.x_points, self.y_points)
+        masked = np.ma.array(mapped, mask=np.ma.getmask(result), copy=False)
+        return masked[0] if is_scalar else masked
+
+    def inverse(self, value):
+        data = np.asarray(value, dtype=float)
+        return np.interp(data, self.y_points, self.x_points)
+
+
+def _latency_baseline_map(topology):
+    """Return topology-specific minima for the load-return metric."""
+    n_subgroups = topology.get("n_subgroups_per_group") or 1
+    if n_subgroups <= 1:
+        return {
+            "local": 1.0,
+            "same_subgroup": 3.0,
+            "same_group": 3.0,
+            "remote": 5.0,
+        }
+    return {
+        "local": 1.0,
+        "same_subgroup": 3.0,
+        "same_group": 5.0,
+        "remote": float(topology["remote_group_latency_cycles"]),
+    }
+
+
+def _build_latency_heatmap(pair_data, topology):
+    """Build the full-section mean latency matrix and locality map."""
+    n_tiles = topology["n_tiles"]
+    latencies = np.full((n_tiles, n_tiles), np.nan)
+    localities = np.full((n_tiles, n_tiles), "", dtype=object)
+    for (source, dest), values in pair_data.items():
+        if values["count"] <= 0:
+            continue
+        latencies[source, dest] = values["lat_sum"] / values["count"]
+        localities[source, dest] = values["locality"]
+    return latencies, localities
+
+
+def _render_latency_heatmap(
+        image_values,
+        annotation_values,
+        topology,
+        output_dir,
+        *,
+        title,
+        save_name,
+        cmap,
+        norm,
+        colorbar_label,
+        colorbar_ticks,
+        footer,
+        colorbar_ticklabels=None):
+    """Render the common tile-pair heatmap frame."""
+    n_groups = topology["n_groups"]
+    n_tiles = len(image_values)
+    tiles_per_group = topology["tiles_per_group"]
+
+    max_px = _matrix_pixel_budget(n_tiles)
+    max_w_inches = max_px / DPI - 3.5
+    max_h_inches = max_px / DPI - 2.5
+    cell_size = min(0.50, max_w_inches / max(n_tiles, 1),
+                    max_h_inches / max(n_tiles, 1))
+    cell_size = max(cell_size, 0.20)
+    fig, ax = plt.subplots(figsize=(n_tiles * cell_size + 3.5,
+                                    n_tiles * cell_size + 2.5))
+    image = ax.imshow(
+        image_values,
+        origin="lower",
+        cmap=cmap,
+        aspect="equal",
+        norm=norm,
+        interpolation="nearest")
+
+    if n_tiles <= MATRIX_ANNOTATION_LIMIT:
+        annotation_size = min(FONT_ANNOT, max(
+            2.0, cell_size * 72 * 0.28))
+        annotation_weight = "bold" if n_tiles <= 32 else "normal"
+        for source in range(n_tiles):
+            for dest in range(n_tiles):
+                value = annotation_values[source, dest]
+                if not np.isnan(value):
+                    ax.text(
+                        dest, source, f"{value:.0f}", ha="center", va="center",
+                        fontsize=annotation_size,
+                        fontweight=annotation_weight, color="black")
+
+    source_offsets = {}
+    for group in range(n_groups):
+        offset = group * tiles_per_group
+        if group > 0:
+            ax.axhline(offset - 0.5, color="#333333", lw=2.0, alpha=0.7)
+        midpoint = offset + tiles_per_group / 2
+        group_color = GRP_COLORS[group % len(GRP_COLORS)]
+        ax.text(-0.04, midpoint, f"G{group}", ha="right", va="center",
+                fontsize=FONT_ANNOT + 3, fontweight="bold", color=group_color,
+                transform=ax.get_yaxis_transform(), clip_on=False)
+        source_offsets[group] = offset
+
+    dest_offsets = {}
+    for group in range(n_groups):
+        offset = group * tiles_per_group
+        if group > 0:
+            ax.axvline(offset - 0.5, color="#333333", lw=2.0, alpha=0.7)
+        midpoint = offset + tiles_per_group / 2
+        group_color = GRP_COLORS[group % len(GRP_COLORS)]
+        ax.text(midpoint, -0.06, f"G{group}", ha="center", va="top",
+                fontsize=FONT_ANNOT + 3, fontweight="bold", color=group_color,
+                transform=ax.get_xaxis_transform(), clip_on=False)
+        dest_offsets[group] = offset
+
+    for group in range(n_groups):
+        origin = (dest_offsets[group] - 0.5, source_offsets[group] - 0.5)
+        group_color = GRP_COLORS[group % len(GRP_COLORS)]
+        for linewidth, color, alpha, zorder in (
+                (8.0, "#000000", 0.25, 4),
+                (5.0, group_color, 0.5, 5),
+                (3.0, group_color, 1.0, 6)):
+            ax.add_patch(Rectangle(
+                origin, tiles_per_group, tiles_per_group,
+                linewidth=linewidth, edgecolor=color, facecolor="none",
+                alpha=alpha, zorder=zorder, clip_on=False))
+
+    _add_subgroup_boxes(ax, topology, tiles_per_group, n_groups)
+
+    tick_size = max(6.5, FONT_TICK - 1.5 * (n_tiles > 48))
+    ax.set_xticks(range(n_tiles))
+    ax.set_yticks(range(n_tiles))
+    ax.set_xticklabels(range(n_tiles), fontsize=tick_size, rotation=90)
+    ax.set_yticklabels(range(n_tiles), fontsize=tick_size)
+    ax.set_xlabel("Destination tile", fontsize=FONT_LABEL, labelpad=20)
+    ax.set_ylabel("Source tile", fontsize=FONT_LABEL)
+    ax.set_title(title, fontsize=FONT_SUBTITLE, fontweight="bold", pad=10)
+
+    divider = make_axes_locatable(ax)
+    colorbar_ax = divider.append_axes("right", size="3.5%", pad=1.00)
+    colorbar = fig.colorbar(image, cax=colorbar_ax)
+    colorbar.set_label(colorbar_label, fontsize=FONT_LABEL - 1)
+    colorbar.set_ticks(colorbar_ticks)
+    if colorbar_ticklabels is not None:
+        colorbar.set_ticklabels(colorbar_ticklabels)
+    colorbar.ax.tick_params(labelsize=FONT_TICK)
+
+    fig.text(0.5, -0.005, footer, ha="center", fontsize=FONT_ANNOT,
+             color="#666666", style="italic")
+    _save(fig, output_dir, save_name)
+
+
+def plot_latency_matrix(pair_data, topology, output_dir, section):
+    """Full-chip tile×tile heatmap of average measured latency per pair."""
+    if not pair_data:
+        print("  [skip] No load_return events with latency")
+        return
+
+    latencies, _ = _build_latency_heatmap(pair_data, topology)
+    n_groups = topology["n_groups"]
+    n_tiles = topology["n_tiles"]
+
+    cmap_lat = LinearSegmentedColormap.from_list(
+        "lat_GnYlRd", LATENCY_CMAP_COLORS, N=256)
+    cmap_lat.set_bad(color="#FFFFFF")
+    n_green = 4
+    remote_cmap_pos = (
+        (n_green - 1) / (len(LATENCY_CMAP_COLORS) - 1))
+    contention_multiple = 3.0
+    log_cmap_end = 0.95
+    tail_multiple = 2.0
+
+    baseline_map = _latency_baseline_map(topology)
+    b_local = baseline_map["local"]
+    b_sub = baseline_map["same_subgroup"]
+    b_remote = baseline_map["remote"]
+
+    vmin_lat = b_local
+    # Keep ideal hierarchy baselines green, reserve most of the remaining
+    # range for contention up to 3× remote, and the final 5% for the tail.
+    vmax_fixed = contention_multiple * b_remote
+    vmax_tail = tail_multiple * vmax_fixed
+
+    x_pts = [vmin_lat]
+    y_pts = [0.0]
+    hierarchy_span = max(b_remote - vmin_lat, 1e-6)
+    for bval in (b_local, b_sub):
+        if bval > vmin_lat:
+            frac = remote_cmap_pos * (bval - vmin_lat) / hierarchy_span
+            x_pts.append(bval)
+            y_pts.append(frac)
+    x_pts.append(b_remote)
+    y_pts.append(remote_cmap_pos)
+    log_denom = np.log(vmax_fixed / b_remote)
+    for i in range(1, 21):
+        f = i / 20.0
+        x_val = b_remote + f * (vmax_fixed - b_remote)
+        y_val = remote_cmap_pos + (
+            log_cmap_end - remote_cmap_pos) * np.log(
+                x_val / b_remote) / log_denom
+        x_pts.append(x_val)
+        y_pts.append(y_val)
+    tail_span = vmax_tail - vmax_fixed
+    for i in range(1, 11):
+        f = i / 10.0
+        x_pts.append(vmax_fixed + f * tail_span)
+        y_pts.append(log_cmap_end + (1.0 - log_cmap_end) * np.sqrt(f))
+    lat_norm = PiecewiseNorm(x_pts, y_pts, vmin=vmin_lat, vmax=vmax_tail)
+
+    _tick_vals = sorted(set(
+        [int(vmin_lat), int(b_sub), int(b_remote)] +
+        list(range(int(b_remote) + 2, int(vmax_fixed), 2)) +
+        [int(vmax_fixed), int(vmax_tail)]))
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+    n_pairs = len(pair_data)
+    total_loads = sum(v["count"] for v in pair_data.values())
+
+    rounded = np.round(latencies)
+    clipped = np.clip(rounded, vmin_lat, vmax_tail)
+    global_avg = (
+        sum(values["lat_sum"] for values in pair_data.values()) /
+        max(1, sum(values["count"] for values in pair_data.values())))
+    footer = (
+        f"{sec_lbl}  ·  {n_tiles} tiles  ·  {n_groups} groups  ·  "
+        f"{n_pairs} active pairs  ·  "
+        f"{_nice_count(total_loads)} load returns  ·  "
+        f"Global avg: {global_avg:.1f} cycles"
+    )
+    _render_latency_heatmap(
+        clipped,
+        rounded,
+        topology,
+        output_dir,
+        title="Load-return latency per tile pair (cycles, mean)",
+        save_name="latency_matrix",
+        cmap=cmap_lat,
+        norm=lat_norm,
+        colorbar_label="Avg latency (cycles)",
+        colorbar_ticks=_tick_vals,
+        colorbar_ticklabels=[
+            str(tick) if tick < vmax_tail else f"{tick}+"
+            for tick in _tick_vals
+        ],
+        footer=footer)
+
+
+def plot_latency_over_minimum(pair_data, topology, output_dir, section):
+    """Tile-pair latency heatmap normalized by hierarchy-aware ideal minima."""
+    if not pair_data:
+        print("  [skip] No load_return events with latency")
+        return
+
+    latencies, localities = _build_latency_heatmap(pair_data, topology)
+    n_groups = topology["n_groups"]
+    n_tiles = topology["n_tiles"]
+
+    baseline_map = _latency_baseline_map(topology)
+
+    cmap_delta = LinearSegmentedColormap.from_list(
+        "lat_over_minimum", LATENCY_CMAP_COLORS, N=256)
+    cmap_delta.set_bad(color="#FFFFFF")
+
+    sec_lbl = f"Section {section}" if section is not None else "All sections"
+    n_pairs = len(pair_data)
+    total_loads = sum(data["count"] for data in pair_data.values())
+
+    delta_mat = np.full_like(latencies, np.nan, dtype=float)
+    for i in range(n_tiles):
+        for j in range(n_tiles):
+            latency = latencies[i, j]
+            if np.isnan(latency):
+                continue
+            locality = localities[i, j] or "remote"
+            delta_mat[i, j] = max(
+                0.0,
+                latency - baseline_map.get(
+                    locality, baseline_map["remote"]))
+
+    delta_mat = np.round(delta_mat)
+    valid_delta = delta_mat[~np.isnan(delta_mat)]
+    vmax_delta = np.ceil(valid_delta.max()) if len(valid_delta) else 1.0
+    vmax_delta = max(1.0, vmax_delta)
+
+    # Expand low excess latencies while compressing the contention tail.
+    base_norm = PowerNorm(gamma=0.38, vmin=0.0, vmax=vmax_delta)
+    if vmax_delta > 2.0:
+        x_points = [0.0, 1.0, min(2.0, vmax_delta)]
+        y_points = [float(base_norm(0.0)),
+                    float(base_norm(min(1.0, vmax_delta))) * 0.78,
+                    float(base_norm(min(2.0, vmax_delta))) * 0.86]
+        if vmax_delta > 10.0:
+            x_points.extend([5.0, 10.0, vmax_delta])
+            y_points.extend([
+                float(base_norm(5.0)),
+                min(0.97, float(base_norm(10.0)) + 0.10),
+                1.0,
+            ])
+        elif vmax_delta > 5.0:
+            x_points.extend([5.0, vmax_delta])
+            y_points.extend([float(base_norm(5.0)), 1.0])
+        else:
+            x_points.append(vmax_delta)
+            y_points.append(1.0)
+        y_points = np.maximum.accumulate(y_points)
+        delta_norm = PiecewiseNorm(
+            x_points, y_points, vmin=0.0, vmax=vmax_delta)
+    else:
+        delta_norm = base_norm
+
+    ticks = sorted(set([0, 1, 2, 5] + [v for v in range(
+                   10, int(vmax_delta) + 1, 5)] + [int(vmax_delta)]))
+    ticks = [tick for tick in ticks if 0 <= tick <= vmax_delta]
+    global_avg_delta = float(
+        np.nanmean(valid_delta)) if len(valid_delta) else 0.0
+    footer = (
+        f"{sec_lbl}  ·  {n_tiles} tiles  ·  {n_groups} groups  ·  "
+        f"{n_pairs} active pairs  ·  "
+        f"{_nice_count(total_loads)} load returns  ·  "
+        f"Global avg excess: {global_avg_delta:.1f} cycles  ·  "
+        f"Baselines: local={baseline_map['local']:.0f}, "
+        f"same-subgroup={baseline_map['same_subgroup']:.0f}, "
+        f"same-group={baseline_map['same_group']:.0f}, "
+        f"remote={baseline_map['remote']:.0f}"
+    )
+    _render_latency_heatmap(
+        delta_mat,
+        delta_mat,
+        topology,
+        output_dir,
+        title="Excess load-return latency above ideal minimum (mean)",
+        save_name="latency_excess_matrix",
+        cmap=cmap_delta,
+        norm=delta_norm,
+        colorbar_label="Excess latency over ideal minimum (cycles)",
+        colorbar_ticks=ticks,
+        footer=footer)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+FIGURE_FAMILIES = (
+    "matrix",
+    "temporal",
+    "latency",
+    "tile_latency",
+    "latency_matrix",
+    "latency_over_minimum",
+)
+
+
+def _parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Analyze communication data and generate traffic and "
+                    "latency plots.")
+    p.add_argument(
+        "result_dir",
+        type=Path,
+        help="Benchmark result directory")
+    p.add_argument("--section", type=int, default=None,
+                   help="Section to plot (default: all)")
+    p.add_argument("--window", type=int, default=64,
+                   help="Time-series bin width in cycles (default: 64)")
+    p.add_argument(
+        "--figures",
+        nargs="+",
+        choices=FIGURE_FAMILIES,
+        metavar="FAMILY",
+        default=None,
+        help=f"Figure families to generate: {', '.join(FIGURE_FAMILIES)} "
+             "(default: all)")
+    args = p.parse_args(argv)
+    if args.window <= 0:
+        p.error("--window must be positive")
+    return args
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    _apply_style()
+
+    result_dir = args.result_dir.resolve()
+    events_path = result_dir / "data" / "comm_events_benchmark.csv"
+    plots_dir = result_dir / "plots"
+    output_dir = plots_dir / "communication"
+    overview_dir = plots_dir / "overview"
+
+    if not events_path.is_file():
+        sys.exit(f"CSV not found: {events_path}")
+
+    section = args.section
+    try:
+        topology = load_topology(result_dir / "topology.env")
+    except ValueError as exc:
+        sys.exit(str(exc))
+    n_groups = topology["n_groups"]
+    figs = set(args.figures or FIGURE_FAMILIES)
+
+    need_timeseries = bool(
+        {"temporal", "latency", "tile_latency"} & figs)
+    aggregates = _scan_events(
+        _iter_events(events_path, section),
+        topology,
+    )
+    if not aggregates["event_count"]:
+        scope = f"section {section}" if section is not None else "the CSV"
+        sys.exit(f"No communication events found for {scope}: {events_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Generating communication figures → {output_dir}")
+
+    timeseries = None
+    if need_timeseries:
+        timeseries = _build_timeseries(
+            _iter_events(events_path, section),
+            topology,
+            args.window,
+            aggregates["cycle_bounds"],
+        )
+
+    if "matrix" in figs:
+        print("\nTraffic matrices …")
+        matrices = aggregates["matrices"]
+        plot_traffic_matrix_full(matrices, topology, output_dir, section)
+        plot_traffic_matrix_group(matrices, topology, output_dir, section)
+
+    if "temporal" in figs and timeseries:
+        print("\nTemporal profile …")
+        plot_temporal_profile(timeseries, overview_dir, section)
+
+    if "latency" in figs and timeseries:
+        print("\nLatency over time …")
+        plot_latency_over_time(timeseries, output_dir, section)
+
+    if "tile_latency" in figs and timeseries:
+        for tg in range(n_groups):
+            print(f"\nPer-tile latency — Group {tg} …")
+            plot_per_tile_group_latency(timeseries, output_dir, section,
+                                        target_group=tg)
+
+    pair_data = aggregates["pair_data"]
+
+    if "latency_matrix" in figs:
+        print("\nTile-pair latency heatmap …")
+        plot_latency_matrix(pair_data, topology, output_dir, section)
+
+    if "latency_over_minimum" in figs:
+        print("\nLatency above hierarchy minimum …")
+        plot_latency_over_minimum(pair_data, topology, output_dir, section)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/src/address_scrambler.sv
+++ b/hardware/src/address_scrambler.sv
@@ -110,7 +110,6 @@ module address_scrambler #(
           if ( (address_i >= start_das_i[p]) && (address_i < start_das_i[p]+MemSizePerRow*rows_das_i[p]) && (tiles_das_i[p] != NumTiles) ) begin
 
             lsb_addr[p]       = address_i & ((1 << (tile_bits[p]+ConstantBitsLSB)) - 1);
-            msb_addr[p]       = address_i & ~((1 << (row_bits[p]+TileIdBits+ConstantBitsLSB)) - 1);
 
             // Narrow subtract: extract the row-index field from the partition
             // start address (masked to row_bits width via rows_das-1), then
@@ -122,6 +121,8 @@ module address_scrambler #(
             aligned_addr[p][RowFieldLSB +: MaxPartitionRowWidth] =
                 address_i[RowFieldLSB +: MaxPartitionRowWidth] - start_row_field[p];
 
+            // Derive every permuted field from the partition-relative address.
+            msb_addr[p]     = aligned_addr[p] & ~((1 << (row_bits[p]+TileIdBits+ConstantBitsLSB)) - 1);
             prt_addr[p]     = (aligned_addr[p] >> row_bits[p]                )  & (((1 << (TileIdBits - tile_bits[p])) - 1) << (ConstantBitsLSB + tile_bits[p]));
             row_addr[p]     = (aligned_addr[p] << (TileIdBits - tile_bits[p]))  & (((1 << (row_bits[p])              ) - 1) << (TileIdBits + ConstantBitsLSB  ));
             address_o       = msb_addr[p] | row_addr[p] | prt_addr[p] | lsb_addr[p];

--- a/hardware/src/mempool_cluster.sv
+++ b/hardware/src/mempool_cluster.sv
@@ -89,7 +89,7 @@ module mempool_cluster
   logic      [NumGroups-1:0] dma_req_group_valid, dma_req_group_q_valid;
   logic      [NumGroups-1:0] dma_req_group_ready, dma_req_group_q_ready;
   dma_meta_t [NumGroups-1:0] dma_meta, dma_meta_q;
-  logic      [RowsInterleavingWidth-1:0] dma_rows_das;
+  logic      [RowsInterleavingWidth:0] dma_rows_das;
 
   `FF(dma_meta_q, dma_meta, '0, clk_i, rst_ni);
 
@@ -103,6 +103,7 @@ module mempool_cluster
     .NumTiles          (NumTiles                    ),
     .NumBanksPerTile   (NumBanksPerTile             ),
     .TCDMSizePerBank   (TCDMSizePerBank             ),
+    .RowsInterleavingWidth (RowsInterleavingWidth    ),
     .NumDASPartitions  (NumDASPartitions            ),
     .NumTilesPerDma    (NumTilesPerDma              ),
     .DASStartAddr      (DASStartAddr                )
@@ -131,8 +132,8 @@ module mempool_cluster
     .DmaRegionStart (TCDMBaseAddr         ),
     .DmaRegionEnd   (TCDMBaseAddr+TCDMSize),
     .TransFifoDepth (16                   ),
-    .NumTiles       (NumTiles             ),
     .NumDASPartitions  (NumDASPartitions  ),
+    .RowsWidth      (RowsInterleavingWidth + 1),
     .burst_req_t    (dma_req_t            ),
     .meta_t         (dma_meta_t           )
   ) i_idma_distributed_midend (

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -77,7 +77,7 @@ module mempool_group
   input  logic                              [NumDASPartitions-1:0][TileInterleavingWidth-1:0] tiles_das_i,
   input  logic                              [NumDASPartitions-1:0][AddrWidth-1:0]             start_das_i,
   input  logic                              [NumDASPartitions-1:0][RowsInterleavingWidth-1:0] rows_das_i,
-  input  logic                              [RowsInterleavingWidth-1:0]                       dma_rows_das_i
+  input  logic                              [RowsInterleavingWidth:0]                         dma_rows_das_i
 `endif
 );
 
@@ -584,8 +584,8 @@ module mempool_group
       .DmaRegionStart (TCDMBaseAddr                            ),
       .DmaRegionEnd   (TCDMBaseAddr+TCDMSize                   ),
       .TransFifoDepth (8                                       ),
-      .NumTiles       (NumTiles                                ),
       .NumDASPartitions  (NumDASPartitions                     ),
+      .RowsWidth      (RowsInterleavingWidth + 1                ),
       .burst_req_t    (dma_req_t                               ),
       .meta_t         (dma_meta_t                              )
     ) i_idma_distributed_midend (
@@ -1127,8 +1127,8 @@ module mempool_group
       .DmaRegionStart (TCDMBaseAddr                            ),
       .DmaRegionEnd   (TCDMBaseAddr+TCDMSize                   ),
       .TransFifoDepth (8                                       ),
-      .NumTiles       (NumTiles                                ),
       .NumDASPartitions  (NumDASPartitions                     ),
+      .RowsWidth      (RowsInterleavingWidth + 1                ),
       .burst_req_t    (dma_req_t                               ),
       .meta_t         (dma_meta_t                              )
     ) i_idma_distributed_midend (

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -642,9 +642,6 @@ module mempool_group
     logic           [NumTilesPerGroup-1:0] tcdm_dma_resp_ready;
 
     // Connect the IOs to the tiles' signals
-    assign tcdm_master_resp[NumGroups-1:1]         = tcdm_master_resp_i[NumGroups-1:1];
-    assign tcdm_master_resp_valid[NumGroups-1:1]   = tcdm_master_resp_valid_i[NumGroups-1:1];
-    assign tcdm_master_resp_ready_o[NumGroups-1:1] = tcdm_master_resp_ready[NumGroups-1:1];
     assign tcdm_slave_req[NumGroups-1:1]           = tcdm_slave_req_i[NumGroups-1:1];
     assign tcdm_slave_req_valid[NumGroups-1:1]     = tcdm_slave_req_valid_i[NumGroups-1:1];
     assign tcdm_slave_req_ready_o[NumGroups-1:1]   = tcdm_slave_req_ready[NumGroups-1:1];
@@ -655,6 +652,14 @@ module mempool_group
     axi_tile_req_t  [NumDmasPerGroup-1:0]  axi_dma_req;
     axi_tile_resp_t [NumDmasPerGroup-1:0]  axi_dma_resp;
 
+    // Tile-facing TCDM input channels.
+    tcdm_master_resp_t [NumTilesPerGroup-1:0][NumGroups-1:0] tile_tcdm_master_resp;
+    logic              [NumTilesPerGroup-1:0][NumGroups-1:0] tile_tcdm_master_resp_valid;
+    logic              [NumTilesPerGroup-1:0][NumGroups-1:0] tile_tcdm_master_resp_ready;
+    tcdm_slave_req_t   [NumTilesPerGroup-1:0][NumGroups-1:0] tile_tcdm_slave_req;
+    logic              [NumTilesPerGroup-1:0][NumGroups-1:0] tile_tcdm_slave_req_valid;
+    logic              [NumTilesPerGroup-1:0][NumGroups-1:0] tile_tcdm_slave_req_ready;
+
     for (genvar t = 0; unsigned'(t) < NumTilesPerGroup; t++) begin: gen_tiles
       tile_id_t id;
       assign id = (group_id_i << $clog2(NumTilesPerGroup)) | t[idx_width(NumTilesPerGroup)-1:0];
@@ -662,12 +667,6 @@ module mempool_group
       tcdm_master_req_t  [NumGroups-1:0] tran_tcdm_master_req;
       logic              [NumGroups-1:0] tran_tcdm_master_req_valid;
       logic              [NumGroups-1:0] tran_tcdm_master_req_ready;
-      tcdm_slave_req_t   [NumGroups-1:0] tran_tcdm_slave_req;
-      logic              [NumGroups-1:0] tran_tcdm_slave_req_valid;
-      logic              [NumGroups-1:0] tran_tcdm_slave_req_ready;
-      tcdm_master_resp_t [NumGroups-1:0] tran_tcdm_master_resp;
-      logic              [NumGroups-1:0] tran_tcdm_master_resp_valid;
-      logic              [NumGroups-1:0] tran_tcdm_master_resp_ready;
       tcdm_slave_resp_t  [NumGroups-1:0] tran_tcdm_slave_resp;
       logic              [NumGroups-1:0] tran_tcdm_slave_resp_valid;
       logic              [NumGroups-1:0] tran_tcdm_slave_resp_ready;
@@ -686,13 +685,13 @@ module mempool_group
         .tcdm_master_req_o       (tran_tcdm_master_req                           ),
         .tcdm_master_req_valid_o (tran_tcdm_master_req_valid                     ),
         .tcdm_master_req_ready_i (tran_tcdm_master_req_ready                     ),
-        .tcdm_master_resp_i      (tran_tcdm_master_resp                          ),
-        .tcdm_master_resp_valid_i(tran_tcdm_master_resp_valid                    ),
-        .tcdm_master_resp_ready_o(tran_tcdm_master_resp_ready                    ),
+        .tcdm_master_resp_i      (tile_tcdm_master_resp[t]                       ),
+        .tcdm_master_resp_valid_i(tile_tcdm_master_resp_valid[t]                 ),
+        .tcdm_master_resp_ready_o(tile_tcdm_master_resp_ready[t]                 ),
         // TCDM banks interface
-        .tcdm_slave_req_i        (tran_tcdm_slave_req                            ),
-        .tcdm_slave_req_valid_i  (tran_tcdm_slave_req_valid                      ),
-        .tcdm_slave_req_ready_o  (tran_tcdm_slave_req_ready                      ),
+        .tcdm_slave_req_i        (tile_tcdm_slave_req[t]                         ),
+        .tcdm_slave_req_valid_i  (tile_tcdm_slave_req_valid[t]                   ),
+        .tcdm_slave_req_ready_o  (tile_tcdm_slave_req_ready[t]                   ),
         .tcdm_slave_resp_o       (tran_tcdm_slave_resp                           ),
         .tcdm_slave_resp_valid_o (tran_tcdm_slave_resp_valid                     ),
         .tcdm_slave_resp_ready_i (tran_tcdm_slave_resp_ready                     ),
@@ -720,16 +719,17 @@ module mempool_group
         assign tcdm_master_req[g][t]          = tran_tcdm_master_req[g];
         assign tcdm_master_req_valid[g][t]    = tran_tcdm_master_req_valid[g];
         assign tran_tcdm_master_req_ready[g]  = tcdm_master_req_ready[g][t];
-        assign tran_tcdm_master_resp[g]       = tcdm_master_resp[g][t];
-        assign tran_tcdm_master_resp_valid[g] = tcdm_master_resp_valid[g][t];
-        assign tcdm_master_resp_ready[g][t]   = tran_tcdm_master_resp_ready[g];
-        assign tran_tcdm_slave_req[g]         = tcdm_slave_req[g][t];
-        assign tran_tcdm_slave_req_valid[g]   = tcdm_slave_req_valid[g][t];
-        assign tcdm_slave_req_ready[g][t]     = tran_tcdm_slave_req_ready[g];
         assign tcdm_slave_resp[g][t]          = tran_tcdm_slave_resp[g];
         assign tcdm_slave_resp_valid[g][t]    = tran_tcdm_slave_resp_valid[g];
         assign tran_tcdm_slave_resp_ready[g]  = tcdm_slave_resp_ready[g][t];
       end: gen_tran_group_req
+
+      assign tile_tcdm_master_resp[t][0]       = tcdm_master_resp[0][t];
+      assign tile_tcdm_master_resp_valid[t][0] = tcdm_master_resp_valid[0][t];
+      assign tcdm_master_resp_ready[0][t]      = tile_tcdm_master_resp_ready[t][0];
+      assign tile_tcdm_slave_req[t][0]         = tcdm_slave_req[0][t];
+      assign tile_tcdm_slave_req_valid[t][0]   = tcdm_slave_req_valid[0][t];
+      assign tcdm_slave_req_ready[0][t]        = tile_tcdm_slave_req_ready[t][0];
     end : gen_tiles
 
     /*************************
@@ -846,6 +846,119 @@ module mempool_group
       tile_group_id_t [NumTilesPerGroup-1:0] slave_remote_resp_ini_addr;
       tcdm_payload_t  [NumTilesPerGroup-1:0] slave_remote_resp_rdata;
 
+    `ifdef BACK2LOCAL
+      // Back2Local paths from the demuxes to the arbiters before the tile ports.
+      logic [NumTilesPerGroup-1:0] slave_back2local_req_valid;
+      logic [NumTilesPerGroup-1:0] slave_back2local_req_ready;
+      logic [NumTilesPerGroup-1:0] master_back2local_resp_valid;
+      logic [NumTilesPerGroup-1:0] master_back2local_resp_ready;
+
+      // Remote interconnect outputs to the demuxes.
+      logic [NumTilesPerGroup-1:0] slave_demux_req_valid;
+      logic [NumTilesPerGroup-1:0] slave_demux_req_ready;
+      logic [NumTilesPerGroup-1:0] master_demux_resp_valid;
+      logic [NumTilesPerGroup-1:0] master_demux_resp_ready;
+
+      for (genvar t = 0; t < NumTilesPerGroup; t++) begin: gen_tile
+        logic [1:0] slave_split_req_valid;
+        logic [1:0] slave_split_req_ready;
+        logic [1:0] master_split_resp_valid;
+        logic [1:0] master_split_resp_ready;
+
+        // Arbiter input 0 is incoming remote; input 1 is Back2Local.
+        logic [1:0] slave_arb_req_valid;
+        logic [1:0] slave_arb_req_ready;
+        tcdm_slave_req_t [1:0] slave_arb_req;
+        logic [1:0] master_arb_resp_valid;
+        logic [1:0] master_arb_resp_ready;
+        tcdm_master_resp_t [1:0] master_arb_resp;
+
+        stream_demux #(
+          .N_OUP(2)
+        ) i_req_demux (
+          .inp_valid_i(slave_demux_req_valid[t]              ),
+          .inp_ready_o(slave_demux_req_ready[t]              ),
+          .oup_sel_i  (slave_remote_req_wdata[t].back2local  ),
+          .oup_valid_o(slave_split_req_valid                 ),
+          .oup_ready_i(slave_split_req_ready                 )
+        );
+
+        assign slave_remote_req_valid[t]     = slave_split_req_valid[0];
+        assign slave_split_req_ready[0]      = slave_remote_req_ready[t];
+        assign slave_back2local_req_valid[t] = slave_split_req_valid[1];
+        assign slave_split_req_ready[1]      = slave_back2local_req_ready[t];
+
+        stream_demux #(
+          .N_OUP(2)
+        ) i_resp_demux (
+          .inp_valid_i(master_demux_resp_valid[t]              ),
+          .inp_ready_o(master_demux_resp_ready[t]              ),
+          .oup_sel_i  (master_remote_resp_rdata[t].back2local  ),
+          .oup_valid_o(master_split_resp_valid                 ),
+          .oup_ready_i(master_split_resp_ready                 )
+        );
+
+        assign master_remote_resp_valid[t]     = master_split_resp_valid[0];
+        assign master_split_resp_ready[0]      = master_remote_resp_ready[t];
+        assign master_back2local_resp_valid[t] = master_split_resp_valid[1];
+        assign master_split_resp_ready[1]      = master_back2local_resp_ready[t];
+
+        assign slave_arb_req[0]                 = tcdm_slave_req[r][t];
+        assign slave_arb_req_valid[0]           = tcdm_slave_req_valid[r][t];
+        assign tcdm_slave_req_ready[r][t]       = slave_arb_req_ready[0];
+        assign slave_arb_req[1]                 = tcdm_master_req_s[r][t];
+        assign slave_arb_req_valid[1]           = slave_back2local_req_valid[t];
+        assign slave_back2local_req_ready[t]    = slave_arb_req_ready[1];
+
+        stream_arbiter #(
+          .DATA_T (tcdm_slave_req_t),
+          .N_INP  (2               ),
+          .ARBITER("rr"            )
+        ) i_req_arbiter (
+          .clk_i      (clk_i                                  ),
+          .rst_ni     (rst_ni                                 ),
+          .inp_data_i (slave_arb_req                           ),
+          .inp_valid_i(slave_arb_req_valid                    ),
+          .inp_ready_o(slave_arb_req_ready                    ),
+          .oup_data_o (tile_tcdm_slave_req[t][r]              ),
+          .oup_valid_o(tile_tcdm_slave_req_valid[t][r]        ),
+          .oup_ready_i(tile_tcdm_slave_req_ready[t][r]        )
+        );
+
+        assign master_arb_resp[0]                  = tcdm_master_resp_i[r][t];
+        assign master_arb_resp_valid[0]            = tcdm_master_resp_valid_i[r][t];
+        assign tcdm_master_resp_ready_o[r][t]      = master_arb_resp_ready[0];
+        assign master_arb_resp[1]                  = tcdm_slave_resp_s[r][t];
+        assign master_arb_resp_valid[1]            = master_back2local_resp_valid[t];
+        assign master_back2local_resp_ready[t]     = master_arb_resp_ready[1];
+
+        stream_arbiter #(
+          .DATA_T (tcdm_master_resp_t),
+          .N_INP  (2                  ),
+          .ARBITER("rr"               )
+        ) i_resp_arbiter (
+          .clk_i      (clk_i                                  ),
+          .rst_ni     (rst_ni                                 ),
+          .inp_data_i (master_arb_resp                         ),
+          .inp_valid_i(master_arb_resp_valid                   ),
+          .inp_ready_o(master_arb_resp_ready                   ),
+          .oup_data_o (tile_tcdm_master_resp[t][r]            ),
+          .oup_valid_o(tile_tcdm_master_resp_valid[t][r]      ),
+          .oup_ready_i(tile_tcdm_master_resp_ready[t][r]      )
+        );
+      end: gen_tile
+
+    `else
+      for (genvar t = 0; t < NumTilesPerGroup; t++) begin: gen_remote_tile_passthrough
+        assign tile_tcdm_master_resp[t][r]       = tcdm_master_resp_i[r][t];
+        assign tile_tcdm_master_resp_valid[t][r] = tcdm_master_resp_valid_i[r][t];
+        assign tcdm_master_resp_ready_o[r][t]    = tile_tcdm_master_resp_ready[t][r];
+        assign tile_tcdm_slave_req[t][r]         = tcdm_slave_req[r][t];
+        assign tile_tcdm_slave_req_valid[t][r]   = tcdm_slave_req_valid[r][t];
+        assign tcdm_slave_req_ready[r][t]        = tile_tcdm_slave_req_ready[t][r];
+      end: gen_remote_tile_passthrough
+    `endif
+
       for (genvar t = 0; t < NumTilesPerGroup; t++) begin: gen_remote_connections
         assign master_remote_req_valid[t]       = tcdm_master_req_valid[r][t];
         assign master_remote_req_tgt_addr[t]    = tcdm_master_req[r][t].tgt_addr;
@@ -891,15 +1004,25 @@ module mempool_group
         .req_wen_i      (master_remote_req_wen     ),
         .req_wdata_i    (master_remote_req_wdata   ),
         .req_be_i       (master_remote_req_be      ),
-        .resp_valid_o   (master_remote_resp_valid  ),
-        .resp_ready_i   (master_remote_resp_ready  ),
+      `ifdef BACK2LOCAL
+        .resp_valid_o   (master_demux_resp_valid  ),
+        .resp_ready_i   (master_demux_resp_ready  ),
+      `else
+        .resp_valid_o   (master_remote_resp_valid ),
+        .resp_ready_i   (master_remote_resp_ready ),
+      `endif
         .resp_rdata_o   (master_remote_resp_rdata  ),
         .resp_ini_addr_i(slave_remote_resp_ini_addr),
         .resp_rdata_i   (slave_remote_resp_rdata   ),
         .resp_valid_i   (slave_remote_resp_valid   ),
         .resp_ready_o   (slave_remote_resp_ready   ),
+      `ifdef BACK2LOCAL
+        .req_valid_o    (slave_demux_req_valid    ),
+        .req_ready_i    (slave_demux_req_ready    ),
+      `else
         .req_valid_o    (slave_remote_req_valid    ),
         .req_ready_i    (slave_remote_req_ready    ),
+      `endif
         .req_be_o       (slave_remote_req_be       ),
         .req_wdata_o    (slave_remote_req_wdata    ),
         .req_wen_o      (slave_remote_req_wen      ),

--- a/hardware/src/mempool_group.sv
+++ b/hardware/src/mempool_group.sv
@@ -266,12 +266,14 @@ module mempool_group
     dma_meta_t [NumDmasPerGroup-1:0] dma_meta;
 
     // Connect the IOs to the SubGroups' signals
+  `ifndef BACK2LOCAL_TERA_GROUP
     assign tcdm_master_resp[NumGroups-1:1]         = tcdm_master_resp_i[NumGroups-1:1];
     assign tcdm_master_resp_valid[NumGroups-1:1]   = tcdm_master_resp_valid_i[NumGroups-1:1];
     assign tcdm_master_resp_ready_o[NumGroups-1:1] = tcdm_master_resp_ready[NumGroups-1:1];
     assign tcdm_slave_req[NumGroups-1:1]           = tcdm_slave_req_i[NumGroups-1:1];
     assign tcdm_slave_req_valid[NumGroups-1:1]     = tcdm_slave_req_valid_i[NumGroups-1:1];
     assign tcdm_slave_req_ready_o[NumGroups-1:1]   = tcdm_slave_req_ready[NumGroups-1:1];
+  `endif
 
     // AXI interfaces
     axi_tile_req_t   [NumAXIMastersPerGroup-1:0] axi_mst_req;
@@ -467,6 +469,113 @@ module mempool_group
       tile_group_id_t [(NumSubGroupsPerGroup * NumTilesPerSubGroup)-1:0] slave_remote_resp_ini_addr;
       tcdm_payload_t  [(NumSubGroupsPerGroup * NumTilesPerSubGroup)-1:0] slave_remote_resp_rdata;
 
+    `ifdef BACK2LOCAL_TERA_GROUP
+      // Back2Local paths from the demuxes to the arbiters before the subgroup ports.
+      logic [NumTilesPerGroup-1:0] slave_back2local_req_valid;
+      logic [NumTilesPerGroup-1:0] slave_back2local_req_ready;
+      logic [NumTilesPerGroup-1:0] master_back2local_resp_valid;
+      logic [NumTilesPerGroup-1:0] master_back2local_resp_ready;
+
+      // Remote interconnect outputs to the demuxes.
+      logic [NumTilesPerGroup-1:0] slave_demux_req_valid;
+      logic [NumTilesPerGroup-1:0] slave_demux_req_ready;
+      logic [NumTilesPerGroup-1:0] master_demux_resp_valid;
+      logic [NumTilesPerGroup-1:0] master_demux_resp_ready;
+
+      for (genvar sg = 0; sg < NumSubGroupsPerGroup; sg++) begin: gen_back2local_sg
+        for (genvar t = 0; t < NumTilesPerSubGroup; t++) begin: gen_back2local_t
+          localparam int unsigned tile_idx = sg * NumTilesPerSubGroup + t;
+
+          logic [1:0] slave_split_req_valid;
+          logic [1:0] slave_split_req_ready;
+          logic [1:0] master_split_resp_valid;
+          logic [1:0] master_split_resp_ready;
+
+          // Arbiter input 0 is incoming remote; input 1 is Back2Local.
+          logic [1:0] slave_arb_req_valid;
+          logic [1:0] slave_arb_req_ready;
+          tcdm_slave_req_t [1:0] slave_arb_req;
+          logic [1:0] master_arb_resp_valid;
+          logic [1:0] master_arb_resp_ready;
+          tcdm_master_resp_t [1:0] master_arb_resp;
+
+          stream_demux #(
+            .N_OUP(2)
+          ) i_req_demux (
+            .inp_valid_i(slave_demux_req_valid[tile_idx]             ),
+            .inp_ready_o(slave_demux_req_ready[tile_idx]             ),
+            .oup_sel_i  (slave_remote_req_wdata[tile_idx].back2local ),
+            .oup_valid_o(slave_split_req_valid                       ),
+            .oup_ready_i(slave_split_req_ready                       )
+          );
+
+          assign slave_remote_req_valid[tile_idx]     = slave_split_req_valid[0];
+          assign slave_split_req_ready[0]             = slave_remote_req_ready[tile_idx];
+          assign slave_back2local_req_valid[tile_idx] = slave_split_req_valid[1];
+          assign slave_split_req_ready[1]             = slave_back2local_req_ready[tile_idx];
+
+          stream_demux #(
+            .N_OUP(2)
+          ) i_resp_demux (
+            .inp_valid_i(master_demux_resp_valid[tile_idx]             ),
+            .inp_ready_o(master_demux_resp_ready[tile_idx]             ),
+            .oup_sel_i  (master_remote_resp_rdata[tile_idx].back2local ),
+            .oup_valid_o(master_split_resp_valid                       ),
+            .oup_ready_i(master_split_resp_ready                       )
+          );
+
+          assign master_remote_resp_valid[tile_idx]     = master_split_resp_valid[0];
+          assign master_split_resp_ready[0]             = master_remote_resp_ready[tile_idx];
+          assign master_back2local_resp_valid[tile_idx] = master_split_resp_valid[1];
+          assign master_split_resp_ready[1]             = master_back2local_resp_ready[tile_idx];
+
+          assign slave_arb_req[0]                      = tcdm_slave_req_i[r][sg][t];
+          assign slave_arb_req_valid[0]                = tcdm_slave_req_valid_i[r][sg][t];
+          assign tcdm_slave_req_ready_o[r][sg][t]      = slave_arb_req_ready[0];
+          assign slave_arb_req[1]                      = tcdm_master_req_s[r][sg][t];
+          assign slave_arb_req_valid[1]                = slave_back2local_req_valid[tile_idx];
+          assign slave_back2local_req_ready[tile_idx]  = slave_arb_req_ready[1];
+
+          stream_arbiter #(
+            .DATA_T (tcdm_slave_req_t),
+            .N_INP  (2               ),
+            .ARBITER("rr"            )
+          ) i_req_arbiter (
+            .clk_i      (clk_i                          ),
+            .rst_ni     (rst_ni                         ),
+            .inp_data_i (slave_arb_req                  ),
+            .inp_valid_i(slave_arb_req_valid            ),
+            .inp_ready_o(slave_arb_req_ready            ),
+            .oup_data_o (tcdm_slave_req[r][sg][t]       ),
+            .oup_valid_o(tcdm_slave_req_valid[r][sg][t] ),
+            .oup_ready_i(tcdm_slave_req_ready[r][sg][t] )
+          );
+
+          assign master_arb_resp[0]                       = tcdm_master_resp_i[r][sg][t];
+          assign master_arb_resp_valid[0]                 = tcdm_master_resp_valid_i[r][sg][t];
+          assign tcdm_master_resp_ready_o[r][sg][t]       = master_arb_resp_ready[0];
+          assign master_arb_resp[1]                       = tcdm_slave_resp_s[r][sg][t];
+          assign master_arb_resp_valid[1]                 = master_back2local_resp_valid[tile_idx];
+          assign master_back2local_resp_ready[tile_idx]   = master_arb_resp_ready[1];
+
+          stream_arbiter #(
+            .DATA_T (tcdm_master_resp_t),
+            .N_INP  (2                  ),
+            .ARBITER("rr"               )
+          ) i_resp_arbiter (
+            .clk_i      (clk_i                            ),
+            .rst_ni     (rst_ni                           ),
+            .inp_data_i (master_arb_resp                  ),
+            .inp_valid_i(master_arb_resp_valid            ),
+            .inp_ready_o(master_arb_resp_ready            ),
+            .oup_data_o (tcdm_master_resp[r][sg][t]       ),
+            .oup_valid_o(tcdm_master_resp_valid[r][sg][t] ),
+            .oup_ready_i(tcdm_master_resp_ready[r][sg][t] )
+          );
+        end: gen_back2local_t
+      end: gen_back2local_sg
+    `endif
+
       for (genvar sg = 0; sg < NumSubGroupsPerGroup; sg++) begin: gen_remote_connections_sg
         for (genvar t = 0; t < NumTilesPerSubGroup; t++) begin: gen_remote_connections_t
           assign master_remote_req_valid[(sg * NumTilesPerSubGroup) + t]    = tcdm_master_req_valid[r][sg][t];
@@ -514,15 +623,25 @@ module mempool_group
         .req_wen_i      (master_remote_req_wen     ),
         .req_wdata_i    (master_remote_req_wdata   ),
         .req_be_i       (master_remote_req_be      ),
+      `ifdef BACK2LOCAL_TERA_GROUP
+        .resp_valid_o   (master_demux_resp_valid  ),
+        .resp_ready_i   (master_demux_resp_ready  ),
+      `else
         .resp_valid_o   (master_remote_resp_valid  ),
         .resp_ready_i   (master_remote_resp_ready  ),
+      `endif
         .resp_rdata_o   (master_remote_resp_rdata  ),
         .resp_ini_addr_i(slave_remote_resp_ini_addr),
         .resp_rdata_i   (slave_remote_resp_rdata   ),
         .resp_valid_i   (slave_remote_resp_valid   ),
         .resp_ready_o   (slave_remote_resp_ready   ),
+      `ifdef BACK2LOCAL_TERA_GROUP
+        .req_valid_o    (slave_demux_req_valid     ),
+        .req_ready_i    (slave_demux_req_ready     ),
+      `else
         .req_valid_o    (slave_remote_req_valid    ),
         .req_ready_i    (slave_remote_req_ready    ),
+      `endif
         .req_be_o       (slave_remote_req_be       ),
         .req_wdata_o    (slave_remote_req_wdata    ),
         .req_wen_o      (slave_remote_req_wen      ),

--- a/hardware/src/mempool_pkg.sv
+++ b/hardware/src/mempool_pkg.sv
@@ -251,6 +251,9 @@ package mempool_pkg;
     meta_id_t meta_id;
     tile_core_id_t core_id;
     amo_t amo;
+  `ifdef BACK2LOCAL
+    logic back2local;
+  `endif
     data_t data;
   } tcdm_payload_t;
 

--- a/hardware/src/mempool_sub_group.sv
+++ b/hardware/src/mempool_sub_group.sv
@@ -143,12 +143,14 @@ module mempool_sub_group
   logic           [NumTilesPerSubGroup-1:0] tcdm_dma_resp_ready;
 
   // Connect the IOs to the tiles' signals
+`ifndef BACK2LOCAL
   assign tcdm_sg_master_resp[NumSubGroupsPerGroup-1:1]         = tcdm_sg_master_resp_i[NumSubGroupsPerGroup-1:1];
   assign tcdm_sg_master_resp_valid[NumSubGroupsPerGroup-1:1]   = tcdm_sg_master_resp_valid_i[NumSubGroupsPerGroup-1:1];
   assign tcdm_sg_master_resp_ready_o[NumSubGroupsPerGroup-1:1] = tcdm_sg_master_resp_ready[NumSubGroupsPerGroup-1:1];
   assign tcdm_sg_slave_req[NumSubGroupsPerGroup-1:1]           = tcdm_sg_slave_req_i[NumSubGroupsPerGroup-1:1];
   assign tcdm_sg_slave_req_valid[NumSubGroupsPerGroup-1:1]     = tcdm_sg_slave_req_valid_i[NumSubGroupsPerGroup-1:1];
   assign tcdm_sg_slave_req_ready_o[NumSubGroupsPerGroup-1:1]   = tcdm_sg_slave_req_ready[NumSubGroupsPerGroup-1:1];
+`endif
 
   // AXI interfaces
   axi_tile_req_t  [NumTilesPerSubGroup-1:0] axi_tile_req;
@@ -361,6 +363,109 @@ module mempool_sub_group
     tile_sub_group_id_t [NumTilesPerSubGroup-1:0] slave_remote_resp_ini_addr;
     tcdm_payload_t      [NumTilesPerSubGroup-1:0] slave_remote_resp_rdata;
 
+  `ifdef BACK2LOCAL
+    // Back2Local paths from the demuxes to the arbiters before the tile ports.
+    logic [NumTilesPerSubGroup-1:0] slave_back2local_req_valid;
+    logic [NumTilesPerSubGroup-1:0] slave_back2local_req_ready;
+    logic [NumTilesPerSubGroup-1:0] master_back2local_resp_valid;
+    logic [NumTilesPerSubGroup-1:0] master_back2local_resp_ready;
+
+    // Remote interconnect outputs to the demuxes.
+    logic [NumTilesPerSubGroup-1:0] slave_demux_req_valid;
+    logic [NumTilesPerSubGroup-1:0] slave_demux_req_ready;
+    logic [NumTilesPerSubGroup-1:0] master_demux_resp_valid;
+    logic [NumTilesPerSubGroup-1:0] master_demux_resp_ready;
+
+    for (genvar t = 0; t < NumTilesPerSubGroup; t++) begin: gen_tile
+      logic [1:0] slave_split_req_valid;
+      logic [1:0] slave_split_req_ready;
+      logic [1:0] master_split_resp_valid;
+      logic [1:0] master_split_resp_ready;
+
+      // Arbiter input 0 is incoming remote; input 1 is Back2Local.
+      logic [1:0] slave_arb_req_valid;
+      logic [1:0] slave_arb_req_ready;
+      tcdm_slave_req_t [1:0] slave_arb_req;
+      logic [1:0] master_arb_resp_valid;
+      logic [1:0] master_arb_resp_ready;
+      tcdm_master_resp_t [1:0] master_arb_resp;
+
+      stream_demux #(
+        .N_OUP(2)
+      ) i_req_demux (
+        .inp_valid_i(slave_demux_req_valid[t]              ),
+        .inp_ready_o(slave_demux_req_ready[t]              ),
+        .oup_sel_i  (slave_remote_req_wdata[t].back2local  ),
+        .oup_valid_o(slave_split_req_valid                 ),
+        .oup_ready_i(slave_split_req_ready                 )
+      );
+
+      assign slave_remote_req_valid[t]     = slave_split_req_valid[0];
+      assign slave_split_req_ready[0]      = slave_remote_req_ready[t];
+      assign slave_back2local_req_valid[t] = slave_split_req_valid[1];
+      assign slave_split_req_ready[1]      = slave_back2local_req_ready[t];
+
+      stream_demux #(
+        .N_OUP(2)
+      ) i_resp_demux (
+        .inp_valid_i(master_demux_resp_valid[t]              ),
+        .inp_ready_o(master_demux_resp_ready[t]              ),
+        .oup_sel_i  (master_remote_resp_rdata[t].back2local  ),
+        .oup_valid_o(master_split_resp_valid                 ),
+        .oup_ready_i(master_split_resp_ready                 )
+      );
+
+      assign master_remote_resp_valid[t]     = master_split_resp_valid[0];
+      assign master_split_resp_ready[0]      = master_remote_resp_ready[t];
+      assign master_back2local_resp_valid[t] = master_split_resp_valid[1];
+      assign master_split_resp_ready[1]      = master_back2local_resp_ready[t];
+
+      assign slave_arb_req[0]                 = tcdm_sg_slave_req_i[r][t];
+      assign slave_arb_req_valid[0]           = tcdm_sg_slave_req_valid_i[r][t];
+      assign tcdm_sg_slave_req_ready_o[r][t]  = slave_arb_req_ready[0];
+      assign slave_arb_req[1]                 = tcdm_sg_master_req_s[r][t];
+      assign slave_arb_req_valid[1]           = slave_back2local_req_valid[t];
+      assign slave_back2local_req_ready[t]    = slave_arb_req_ready[1];
+
+      stream_arbiter #(
+        .DATA_T (tcdm_slave_req_t),
+        .N_INP  (2               ),
+        .ARBITER("rr"            )
+      ) i_req_arbiter (
+        .clk_i      (clk_i                         ),
+        .rst_ni     (rst_ni                        ),
+        .inp_data_i (slave_arb_req                 ),
+        .inp_valid_i(slave_arb_req_valid           ),
+        .inp_ready_o(slave_arb_req_ready           ),
+        .oup_data_o (tcdm_sg_slave_req[r][t]       ),
+        .oup_valid_o(tcdm_sg_slave_req_valid[r][t] ),
+        .oup_ready_i(tcdm_sg_slave_req_ready[r][t] )
+      );
+
+      assign master_arb_resp[0]                  = tcdm_sg_master_resp_i[r][t];
+      assign master_arb_resp_valid[0]            = tcdm_sg_master_resp_valid_i[r][t];
+      assign tcdm_sg_master_resp_ready_o[r][t]   = master_arb_resp_ready[0];
+      assign master_arb_resp[1]                  = tcdm_sg_slave_resp_s[r][t];
+      assign master_arb_resp_valid[1]            = master_back2local_resp_valid[t];
+      assign master_back2local_resp_ready[t]     = master_arb_resp_ready[1];
+
+      stream_arbiter #(
+        .DATA_T (tcdm_master_resp_t),
+        .N_INP  (2                  ),
+        .ARBITER("rr"               )
+      ) i_resp_arbiter (
+        .clk_i      (clk_i                           ),
+        .rst_ni     (rst_ni                          ),
+        .inp_data_i (master_arb_resp                 ),
+        .inp_valid_i(master_arb_resp_valid           ),
+        .inp_ready_o(master_arb_resp_ready           ),
+        .oup_data_o (tcdm_sg_master_resp[r][t]       ),
+        .oup_valid_o(tcdm_sg_master_resp_valid[r][t] ),
+        .oup_ready_i(tcdm_sg_master_resp_ready[r][t] )
+      );
+    end: gen_tile
+  `endif
+
     for (genvar t = 0; t < NumTilesPerSubGroup; t++) begin: gen_remote_connections_t
       assign master_remote_req_valid[t]          = tcdm_sg_master_req_valid[r][t];
       assign master_remote_req_tgt_addr[t]       = tcdm_sg_master_req[r][t].tgt_addr;
@@ -406,15 +511,25 @@ module mempool_sub_group
       .req_wen_i      (master_remote_req_wen     ),
       .req_wdata_i    (master_remote_req_wdata   ),
       .req_be_i       (master_remote_req_be      ),
+    `ifdef BACK2LOCAL
+      .resp_valid_o   (master_demux_resp_valid  ),
+      .resp_ready_i   (master_demux_resp_ready  ),
+    `else
       .resp_valid_o   (master_remote_resp_valid  ),
       .resp_ready_i   (master_remote_resp_ready  ),
+    `endif
       .resp_rdata_o   (master_remote_resp_rdata  ),
       .resp_ini_addr_i(slave_remote_resp_ini_addr),
       .resp_rdata_i   (slave_remote_resp_rdata   ),
       .resp_valid_i   (slave_remote_resp_valid   ),
       .resp_ready_o   (slave_remote_resp_ready   ),
+    `ifdef BACK2LOCAL
+      .req_valid_o    (slave_demux_req_valid     ),
+      .req_ready_i    (slave_demux_req_ready     ),
+    `else
       .req_valid_o    (slave_remote_req_valid    ),
       .req_ready_i    (slave_remote_req_ready    ),
+    `endif
       .req_be_o       (slave_remote_req_be       ),
       .req_wdata_o    (slave_remote_req_wdata    ),
       .req_wen_o      (slave_remote_req_wen      ),

--- a/hardware/src/mempool_tile.sv
+++ b/hardware/src/mempool_tile.sv
@@ -819,6 +819,19 @@ module mempool_tile
 
   for (genvar c = 0; c < NumCoresPerTile; c++) begin: gen_core_mux
     `ifdef TERAPOOL
+    `ifdef BACK2LOCAL
+      logic subgroup_back2local;
+
+      // Distribute same-subgroup requests over the enabled tile ports.
+    `ifdef BACK2LOCAL_TERA_GROUP
+      localparam tile_remote_sel_t Back2LocalPort =
+          tile_remote_sel_t'(c % (NumGroups + NumSubGroupsPerGroup - 1));
+    `else
+      localparam tile_remote_sel_t Back2LocalPort =
+          tile_remote_sel_t'(c % NumSubGroupsPerGroup);
+    `endif
+    `endif
+
       // Remove tile index from local_req_interco_addr_int, since it will not be used for routing.
       addr_t local_req_interco_addr_int;
       assign local_req_interco_payload[c].tgt_addr =
@@ -833,7 +846,11 @@ module mempool_tile
            prescramble_tcdm_req_tgt_addr[ByteOffset +: idx_width(NumBanksPerTile)]}); // Tile
       end else begin : gen_remote_req_interco_tgt_addr
         always_comb begin
+        `ifdef BACK2LOCAL_TERA_GROUP
+          if (remote_req_interco_tgt_sel[c] < tile_remote_sel_t'(NumSubGroupsPerGroup)) begin
+        `else
           if (remote_req_interco_tgt_g_sel_tmp[c] == 'b0) begin
+        `endif
             remote_req_interco[c].tgt_addr =
             tcdm_addr_t'({prescramble_tcdm_req_tgt_addr[ByteOffset + idx_width(NumBanksPerTile) + $clog2(NumTilesPerGroup) + $clog2(NumGroups) +: TCDMAddrMemWidth], // Bank address
             prescramble_tcdm_req_tgt_addr[ByteOffset +: idx_width(NumBanksPerTile)], // Bank
@@ -851,22 +868,48 @@ module mempool_tile
       if (NumGroups == 1) begin : gen_remote_req_interco_tgt_sel
         if (NumSubGroupsPerGroup == 1) begin : gen_const_sel
           assign remote_req_interco_tgt_sel[c] = 1'b0;
+        `ifdef BACK2LOCAL
+          assign subgroup_back2local = 1'b0;
+        `endif
         end else begin : gen_const_sel
+        `ifdef BACK2LOCAL
+          assign remote_req_interco_tgt_sg_sel_tmp[c] = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerSubGroup) +: $clog2(NumSubGroupsPerGroup)]) ^ sub_group_id;
+          assign subgroup_back2local = (remote_req_interco_tgt_sg_sel_tmp[c] == '0);
+          always_comb begin
+            remote_req_interco_tgt_sel[c] = remote_req_interco_tgt_sg_sel_tmp[c];
+            if (subgroup_back2local) begin
+              remote_req_interco_tgt_sel[c] = Back2LocalPort;
+            end
+          end
+        `else
           assign remote_req_interco_tgt_sel[c] = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerSubGroup) +: $clog2(NumSubGroupsPerGroup)]) ^ sub_group_id;
+        `endif
         end
       end else begin : gen_remote_req_interco_tgt_sel
         // Output port depends on both the target and initiator group and sub-group
         if (NumSubGroupsPerGroup == 1) begin : gen_remote_group_sel
           assign remote_req_interco_tgt_sel[c] = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerGroup) +: $clog2(NumGroups)]) ^ group_id;
+        `ifdef BACK2LOCAL
+          assign subgroup_back2local = 1'b0;
+        `endif
         end else begin : gen_remote_group_sel
           assign remote_req_interco_tgt_g_sel_tmp[c]  = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerGroup) +: $clog2(NumGroups)]) ^ group_id;
           assign remote_req_interco_tgt_sg_sel_tmp[c] = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerSubGroup) +: $clog2(NumSubGroupsPerGroup)]) ^ sub_group_id;
+        `ifdef BACK2LOCAL
+          assign subgroup_back2local = (remote_req_interco_tgt_g_sel_tmp[c] == '0) &&
+                                       (remote_req_interco_tgt_sg_sel_tmp[c] == '0);
+        `endif
           always_comb begin : gen_remote_sub_group_sel
             if (remote_req_interco_tgt_g_sel_tmp[c] == 'b0) begin: gen_local_group_sel
               remote_req_interco_tgt_sel[c] = remote_req_interco_tgt_sg_sel_tmp[c];
             end else begin: gen_remote_group_sel
               remote_req_interco_tgt_sel[c] = remote_req_interco_tgt_g_sel_tmp[c] + {(idx_width(NumSubGroupsPerGroup)){1'b1}};
             end
+          `ifdef BACK2LOCAL
+            if (subgroup_back2local) begin
+              remote_req_interco_tgt_sel[c] = Back2LocalPort;
+            end
+          `endif
           end
         end
       end
@@ -912,7 +955,13 @@ module mempool_tile
     assign remote_req_interco[c].wdata.core_id = c[idx_width(NumCoresPerTile)-1:0];
 
   `ifdef BACK2LOCAL
+    `ifdef TERAPOOL
+    // Mark same-subgroup requests. Borrowed-port boundaries use this bit
+    // to loop them back; the normal port ignores it.
+    assign remote_req_interco[c].wdata.back2local = subgroup_back2local;
+    `else
     assign remote_req_interco[c].wdata.back2local = (remote_req_interco_tgt_g_sel[c] == '0);
+    `endif
     assign local_req_interco_payload[c].wdata.back2local = 1'b0;
   `endif
 

--- a/hardware/src/mempool_tile.sv
+++ b/hardware/src/mempool_tile.sv
@@ -366,6 +366,9 @@ module mempool_tile
     meta_id_t meta_id;
     tile_group_id_t tile_id;
     tile_core_id_t core_id;
+  `ifdef BACK2LOCAL
+    logic back2local;
+  `endif
     logic wide;
   } bank_metadata_t;
 
@@ -507,6 +510,9 @@ module mempool_tile
       meta_id   : bank_req_payload[b].wdata.meta_id,
       core_id   : bank_req_payload[b].wdata.core_id,
       tile_id   : bank_req_payload[b].ini_addr,
+    `ifdef BACK2LOCAL
+      back2local: bank_req_payload[b].wdata.back2local,
+    `endif
       wide      : bank_req_wide[b]
     };
     assign bank_resp_ini_addr[b]              = meta_out.ini_addr;
@@ -514,6 +520,9 @@ module mempool_tile
     assign bank_resp_payload[b].ini_addr      = meta_out.tile_id;
     assign bank_resp_payload[b].rdata.core_id = meta_out.core_id;
     assign bank_resp_payload[b].rdata.amo     = '0; // Don't care
+  `ifdef BACK2LOCAL
+    assign bank_resp_payload[b].rdata.back2local = meta_out.back2local;
+  `endif
     assign bank_resp_wide[b]                  = meta_out.wide;
 
     tcdm_adapter #(
@@ -662,6 +671,7 @@ module mempool_tile
     sgroup_group_id_t  [NumCoresPerTile-1:0] remote_req_interco_tgt_sg_sel_tmp;
   `else
     group_id_t         [NumCoresPerTile-1:0] remote_req_interco_tgt_sel;
+    group_id_t         [NumCoresPerTile-1:0] remote_req_interco_tgt_g_sel;
   `endif
 
   stream_xbar #(
@@ -880,10 +890,16 @@ module mempool_tile
            prescramble_tcdm_req_tgt_addr[ByteOffset + idx_width(NumBanksPerTile) +: $clog2(NumTilesPerGroup)]}); // Tile
       end
       if (NumGroups == 1) begin : gen_remote_req_interco_tgt_sel
+        assign remote_req_interco_tgt_g_sel[c] = '0;
         assign remote_req_interco_tgt_sel[c] = 1'b0;
       end else begin : gen_remote_req_interco_tgt_sel
-        // Output port depends on both the target and initiator group
-        assign remote_req_interco_tgt_sel[c] = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerGroup) +: $clog2(NumGroups)]) ^ group_id;
+        // Compute the normal output port before Back2Local rerouting.
+        assign remote_req_interco_tgt_g_sel[c] = (prescramble_tcdm_req_tgt_addr[ByteOffset + $clog2(NumBanksPerTile) + $clog2(NumTilesPerGroup) +: $clog2(NumGroups)]) ^ group_id;
+      `ifdef BACK2LOCAL
+        assign remote_req_interco_tgt_sel[c] = (remote_req_interco_tgt_g_sel[c] == '0) ? group_id_t'(c % NumGroups) : remote_req_interco_tgt_g_sel[c];
+      `else
+        assign remote_req_interco_tgt_sel[c] = remote_req_interco_tgt_g_sel[c];
+      `endif
       end
     `endif
 
@@ -894,6 +910,11 @@ module mempool_tile
 
     // Constant value
     assign remote_req_interco[c].wdata.core_id = c[idx_width(NumCoresPerTile)-1:0];
+
+  `ifdef BACK2LOCAL
+    assign remote_req_interco[c].wdata.back2local = (remote_req_interco_tgt_g_sel[c] == '0);
+    assign local_req_interco_payload[c].wdata.back2local = 1'b0;
+  `endif
 
     // Scramble address before entering TCDM shim for sequential+interleaved memory map
     addr_t snitch_data_qaddr_scrambled;

--- a/hardware/tb/mempool_tb.sv
+++ b/hardware/tb/mempool_tb.sv
@@ -6,6 +6,42 @@ import "DPI-C" function void read_elf (input string filename);
 import "DPI-C" function byte get_section (output longint address, output longint len);
 import "DPI-C" context function byte read_section(input longint address, inout byte buffer[]);
 
+// Per-hart TCDM address trace. It records the physical address of each accepted
+// LSU request. The assertion checks that it stays aligned with the real scrambler.
+`ifdef TCDM_ADDR_TRACE
+module mempool_tcdm_addr_tracer
+  import mempool_pkg::*;
+#(
+  parameter int unsigned HartId = 0
+) (
+  input logic                       clk_i,
+  input logic                       rst_ni,
+  input logic                       valid_i,
+  input logic [63:0]                cycle_i,
+  input logic [AddrWidth-1:0]       lsu_addr_i,
+  input logic [AddrWidth-1:0]       scrambler_addr_i,
+  input logic [AddrWidth-1:0]       tcdm_addr_i
+);
+  int f;
+  string fn;
+
+  initial begin
+    $sformat(fn, "tcdm_addr_hart_0x%08x.csv", HartId);
+    f = $fopen(fn, "w");
+  end
+
+  always_ff @(posedge clk_i) begin
+    if (rst_ni && valid_i) begin
+      assert (scrambler_addr_i == {lsu_addr_i[AddrWidth-1:2], 2'b0})
+        else $fatal(1, "TCDM trace misalignment for hart %0d at cycle %0d", HartId, cycle_i);
+      $fwrite(f, "%0d,0x%08x\n", cycle_i, tcdm_addr_i);
+    end
+  end
+
+  final $fclose(f);
+endmodule
+`endif
+
 `define wait_for(signal) \
   do \
     @(posedge clk); \
@@ -198,7 +234,21 @@ module mempool_tb;
       for (genvar sg = 0; sg < NumSubGroupsPerGroup; sg++) begin: gen_wfi_sub_groups
         for (genvar t = 0; t < NumTilesPerSubGroup; t++) begin: gen_wfi_tiles
           for (genvar c = 0; c < NumCoresPerTile; c++) begin: gen_wfi_cores
-            assign wfi[g*NumSubGroupsPerGroup*NumTilesPerSubGroup*NumCoresPerTile + sg*NumTilesPerSubGroup*NumCoresPerTile + t*NumCoresPerTile + c] = dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.wfi_q;
+            localparam int unsigned HartId = g*NumSubGroupsPerGroup*NumTilesPerSubGroup*NumCoresPerTile + sg*NumTilesPerSubGroup*NumCoresPerTile + t*NumCoresPerTile + c;
+            assign wfi[HartId] = dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.wfi_q;
+            `ifdef TCDM_ADDR_TRACE
+            mempool_tcdm_addr_tracer #(
+              .HartId(HartId)
+            ) i_tcdm_addr_tracer (
+              .clk_i    (clk),
+              .rst_ni   (rst_n),
+              .valid_i  (dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.lsu_qvalid && dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.lsu_qready),
+              .cycle_i  (dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.cycle),
+              .lsu_addr_i(dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.lsu_qaddr),
+              .scrambler_addr_i(dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_core_mux[c].i_address_scrambler.address_i),
+              .tcdm_addr_i(dut.i_mempool_cluster.gen_groups[g].gen_rtl_group.i_group.gen_sub_groups[sg].gen_rtl_sg.i_sub_group.gen_tiles[t].i_tile.gen_core_mux[c].snitch_data_qaddr_scrambled)
+            );
+            `endif
           end: gen_wfi_cores
         end: gen_wfi_tiles
       end: gen_wfi_sub_groups
@@ -207,7 +257,21 @@ module mempool_tb;
     for (genvar g = 0; g < NumGroups; g++) begin: gen_wfi_groups
       for (genvar t = 0; t < NumTilesPerGroup; t++) begin: gen_wfi_tiles
         for (genvar c = 0; c < NumCoresPerTile; c++) begin: gen_wfi_cores
-          assign wfi[g*NumTilesPerGroup*NumCoresPerTile + t*NumCoresPerTile + c] = dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.wfi_q;
+          localparam int unsigned HartId = g*NumTilesPerGroup*NumCoresPerTile + t*NumCoresPerTile + c;
+          assign wfi[HartId] = dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.wfi_q;
+          `ifdef TCDM_ADDR_TRACE
+          mempool_tcdm_addr_tracer #(
+            .HartId(HartId)
+          ) i_tcdm_addr_tracer (
+            .clk_i    (clk),
+            .rst_ni   (rst_n),
+            .valid_i  (dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.lsu_qvalid && dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.lsu_qready),
+            .cycle_i  (dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.cycle),
+            .lsu_addr_i(dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_cores[c].gen_mempool_cc.riscv_core.i_snitch.lsu_qaddr),
+            .scrambler_addr_i(dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_core_mux[c].i_address_scrambler.address_i),
+            .tcdm_addr_i(dut.i_mempool_cluster.gen_groups[g].i_group.gen_tiles[t].i_tile.gen_core_mux[c].snitch_data_qaddr_scrambled)
+          );
+          `endif
         end: gen_wfi_cores
       end: gen_wfi_tiles
     end: gen_wfi_groups

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -16,3 +16,4 @@ tabulate
 sympy
 scipy
 pyflexfloat
+matplotlib

--- a/software/data/gendatalib.py
+++ b/software/data/gendatalib.py
@@ -427,7 +427,7 @@ def generate_imatmul(my_type=np.int32, defines={}):
     matrix_P = defines['matrix_P']
     MAX = select_maxval(my_type)
     A = irandom(MAX=MAX, size=(matrix_M, matrix_N), my_type=my_type)
-    B = irandom(MAX=MAX, size=(matrix_M, matrix_N), my_type=my_type)
+    B = irandom(MAX=MAX, size=(matrix_N, matrix_P), my_type=my_type)
     C = np.matmul(A, B)
 
     A = np.reshape(A, (matrix_M * matrix_N), order='C').astype(my_type)

--- a/software/runtime/runtime.mk
+++ b/software/runtime/runtime.mk
@@ -111,7 +111,7 @@ ifdef terapool
 	DEFINES += -DNUM_CORES_PER_SUB_GROUP=$(shell awk 'BEGIN{print ($(num_cores)/$(num_groups))/$(num_sub_groups_per_group)}')
 	DEFINES += -DNUM_TILES_PER_SUB_GROUP=$(shell awk 'BEGIN{print ($(num_cores)/$(num_groups))/$(num_cores_per_tile)/$(num_sub_groups_per_group)}')
 endif
-ifdef das
+ifeq ($(das),1)
 	DEFINES += -DNUM_DAS_PARTITIONS=$(num_das_partitions)
 	DEFINES += -DDAS_MEM_SIZE=$(das_mem_size)
 	DEFINES += -DLOG2_DAS_MEM_SIZE=$(shell awk 'BEGIN{print log($(das_mem_size))/log(2)}')


### PR DESCRIPTION
This PR adds Back2Local routing for MemPool and TeraPool, together with a
benchmark analysis and plotting pipeline built on the existing trace
infrastructure.

## Changelog

### Added

- Add Back2Local interconnect extensions and a tile-port rerouting mechanism for
  MemPool and TeraPool.
- Add benchmark data extraction and plotting for performance and communication
  analysis.
- Add a testbench observer for physical TCDM addresses after DAS scrambling,
  enabling correct destination analysis.

### Fixed

- Fix DAS row-width and start-address handling in the DMA path.
- Fix DAS scrambling for partitions with offset start addresses.
- Fix the B matrix shape generated by `generate_imatmul`.

## Validation

Tested a 256×64×256 integer matrix multiplication using the 4×4 DAS assembly
kernel on MemPool with Back2Local disabled and enabled, and on TeraPool with
Back2Local disabled, subgroup routing enabled, and subgroup plus group routing
enabled.

All five runs completed with `0 ERRORS out of 65536 CHECKS`. Benchmark data
extraction and plot generation also completed successfully.

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed